### PR TITLE
Basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ ReactDOM.render(
 ```javascript
 {
 	url: "..." // the search url
+	userpass: "btoa('username:password')" // [optional, the username/password if your Solr server requires basic auth ]
+	// This login should only allow read access and should NOT be considered secure as it will be trivially accessible by the client.
 	searchFields: [{...}] // the search field configuration
 	sortFields: [{...}] // the sort field configuration,
 	onChange: (state, handlers) => {...} // the change handler for query and result state

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -17,8 +17,9 @@ server.submitQuery = (query, callback) => {
 		data: solrQuery(query),
 		method: "POST",
 		headers: {
-			"Content-type": "application/x-www-form-urlencoded"
-		}
+			"Content-type": "application/x-www-form-urlencoded",
+			...(query.userpass ? {"Authorization": "Basic " + query.userpass} : {}),
+        }
 	}, (err, resp) => {
 		if (resp.statusCode >= 200 && resp.statusCode < 300) {
 			callback({type: "SET_RESULTS", data: JSON.parse(resp.body)});
@@ -38,8 +39,9 @@ server.fetchCsv = (query, callback) => {
 		}),
 		method: "POST",
 		headers: {
-			"Content-type": "application/x-www-form-urlencoded"
-		}
+			"Content-type": "application/x-www-form-urlencoded",
+			...(query.userpass ? {"Authorization": "Basic " + query.userpass} : {}),
+        }
 	}, (err, resp) => {
 		if (resp.statusCode >= 200 && resp.statusCode < 300) {
 			callback(resp.body);


### PR DESCRIPTION
Configures a `userpass` parameter which contains a base64 encoded version of `username:password` to pass to the server in the headers as `Authorization: Basic {userpass}` if set. This allows access to Solr servers that require Basic Authentication.