### PR TITLE
PL-10-Add-config-option-to-allow-for-empty-search

### DIFF
--- a/src/api/solr-query.js
+++ b/src/api/solr-query.js
@@ -96,7 +96,12 @@ const buildMainQuery = (fields, mainQueryField) => {
   }
   // If there is only one main query field, add only it.
   else if (params.length === 1) {
-    qs += params[0];
+    if (params[0] !== null) {
+      qs += params[0];
+    } else {
+      // If query field exists but is null send the wildcard query.
+      qs += "*:*";
+    }
   }
   // If there are no main query fields, send the wildcard query.
   else {


### PR DESCRIPTION
[PL-10](https://palantir.atlassian.net/browse/PL-10)

## Ticket Description
Add "Show results for empty search" (`empty-search-results` or something) option to federated-search-react and create the corresponding config option search_api_federated_solr D8 and D7 branches. This should be a boolean that defaults to false.
Reconfigure react components to behave based on that config.

## PR Description
This PR simply fixes an issue where even if search is empty, the `param` array has a single value of null. Logic was added to send the wildcard query if `param == null`

## To Test (from federated-search-react repo)
1. Run `yarn install` from the ederated-search-react repo root.
1. Create a `src/.env.local.js` configuration file.
1. Add this branch to federated-search-react
1. set `showEmptySearchResults: true` in .env.local.js
1. Configure the search app to use a solr server ( I used http://federated-search-demo.local:8983/solr/drupal8/select)
1.  run `yarn start`
1. View that search shows results with an empty search.
