### PR TITLE
Root-198: add search-as-you-type suggestion query functionality

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1601,7 +1601,7 @@ function extend() {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -1621,51 +1621,71 @@ var MAX_INT = 2147483647;
 var server = {};
 
 server.performXhr = function (options, accept) {
-	var reject = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () {
-		console.warn("Undefined reject callback! ");(console.trace || function () {})();
-	};
+  var reject = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () {
+    console.warn("Undefined reject callback! ");
+    (console.trace || function () {})();
+  };
 
-	(0, _xhr2.default)(options, accept, reject);
+  (0, _xhr2.default)(options, accept, reject);
 };
 
 server.submitQuery = function (query, callback) {
-	callback({ type: "SET_RESULTS_PENDING" });
+  callback({ type: "SET_RESULTS_PENDING" });
 
-	server.performXhr({
-		url: query.url,
-		data: (0, _solrQuery2.default)(query),
-		method: "POST",
-		headers: {
-			"Content-type": "application/x-www-form-urlencoded"
-		}
-	}, function (err, resp) {
-		if (resp.statusCode >= 200 && resp.statusCode < 300) {
-			callback({ type: "SET_RESULTS", data: JSON.parse(resp.body) });
-		} else {
-			console.log("Server error: ", resp.statusCode);
-		}
-	});
+  server.performXhr({
+    url: query.url,
+    data: (0, _solrQuery2.default)(query),
+    method: "POST",
+    headers: _extends({
+      "Content-type": "application/x-www-form-urlencoded"
+    }, query.userpass ? { "Authorization": "Basic " + query.userpass } : {})
+  }, function (err, resp) {
+    if (resp.statusCode >= 200 && resp.statusCode < 300) {
+      callback({ type: "SET_RESULTS", data: JSON.parse(resp.body) });
+    } else {
+      console.log("Server error: ", resp.statusCode);
+    }
+  });
+};
+
+server.submitSuggestQuery = function (suggestQuery, callback) {
+  callback({ type: "SET_SUGGESTIONS_PENDING" });
+
+  server.performXhr({
+    url: suggestQuery.url,
+    data: (0, _solrQuery.solrSuggestQuery)(suggestQuery),
+    method: "POST",
+    headers: _extends({
+      "Content-type": "application/x-www-form-urlencoded"
+    }, suggestQuery.userpass ? { "Authorization": "Basic " + suggestQuery.userpass } : {})
+  }, function (err, resp) {
+    if (resp.statusCode >= 200 && resp.statusCode < 300) {
+      callback({ type: "SET_SUGGESTIONS", data: JSON.parse(resp.body) });
+    } else {
+      console.log("Server error: ", resp.statusCode);
+    }
+  });
 };
 
 server.fetchCsv = function (query, callback) {
-	server.performXhr({
-		url: query.url,
-		data: (0, _solrQuery2.default)(_extends({}, query, { rows: MAX_INT }), {
-			wt: "csv",
-			"csv.mv.separator": "|",
-			"csv.separator": ";"
-		}),
-		method: "POST",
-		headers: {
-			"Content-type": "application/x-www-form-urlencoded"
-		}
-	}, function (err, resp) {
-		if (resp.statusCode >= 200 && resp.statusCode < 300) {
-			callback(resp.body);
-		} else {
-			console.log("Server error: ", resp.statusCode);
-		}
-	});
+  server.performXhr({
+    url: query.url,
+    data: (0, _solrQuery2.default)(_extends({}, query, { rows: MAX_INT }), {
+      wt: "csv",
+      "csv.mv.separator": "|",
+      "csv.separator": ";"
+    }),
+    method: "POST",
+    headers: _extends({
+      "Content-type": "application/x-www-form-urlencoded"
+    }, query.userpass ? { "Authorization": "Basic " + query.userpass } : {})
+  }, function (err, resp) {
+    if (resp.statusCode >= 200 && resp.statusCode < 300) {
+      callback(resp.body);
+    } else {
+      console.log("Server error: ", resp.statusCode);
+    }
+  });
 };
 
 exports.default = server;
@@ -1674,7 +1694,7 @@ exports.default = server;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 exports.SolrClient = undefined;
 
@@ -1692,6 +1712,14 @@ var _results = _dereq_("../reducers/results");
 
 var _results2 = _interopRequireDefault(_results);
 
+var _suggestions = _dereq_("../reducers/suggestions");
+
+var _suggestions2 = _interopRequireDefault(_suggestions);
+
+var _suggestQuery = _dereq_("../reducers/suggestQuery");
+
+var _suggestQuery2 = _interopRequireDefault(_suggestQuery);
+
 var _server = _dereq_("./server");
 
 var _server2 = _interopRequireDefault(_server);
@@ -1701,232 +1729,280 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var SolrClient = function () {
-	function SolrClient(settings) {
-		_classCallCheck(this, SolrClient);
+  function SolrClient(settings) {
+    _classCallCheck(this, SolrClient);
 
-		var onChange = settings.onChange;
+    var onChange = settings.onChange;
 
 
-		this.onChange = onChange;
-		delete settings.onChange;
+    this.onChange = onChange;
+    delete settings.onChange;
 
-		this.state = {
-			query: settings,
-			results: {
-				facets: [],
-				docs: [],
-				highlighting: [],
-				numFound: 0
-			}
-		};
-		this.settings = _extends({}, settings);
+    this.state = {
+      query: settings,
+      results: {
+        facets: [],
+        docs: [],
+        highlighting: [],
+        numFound: 0
+      }
+    };
+    this.settings = _extends({}, settings);
 
-		if (!this.state.query.pageStrategy) {
-			this.state.query.pageStrategy = "paginate";
-		}
-		if (!this.state.query.rows) {
-			this.state.query.rows = 20;
-		}
+    if (!this.state.query.pageStrategy) {
+      this.state.query.pageStrategy = "paginate";
+    }
+    if (!this.state.query.rows) {
+      this.state.query.rows = 20;
+    }
 
-		if (this.state.query.pageStrategy === "cursor" && !this.state.query.idField) {
-			throw new Error("Pagination strategy 'cursor' requires a unique 'idField' to be passed.");
-		}
-	}
+    if (this.state.query.pageStrategy === "cursor" && !this.state.query.idField) {
+      throw new Error("Pagination strategy 'cursor' requires a unique 'idField' to be passed.");
+    }
+  }
 
-	_createClass(SolrClient, [{
-		key: "setInitialQuery",
-		value: function setInitialQuery(queryToMerge) {
+  _createClass(SolrClient, [{
+    key: "setInitialQuery",
+    value: function setInitialQuery(queryToMerge) {
 
-			var searchFieldsToMerge = queryToMerge.searchFields || [];
-			var sortFieldsToMerge = queryToMerge.sortFields || [];
+      var searchFieldsToMerge = queryToMerge.searchFields || [];
+      var sortFieldsToMerge = queryToMerge.sortFields || [];
 
-			this.state.query.searchFields = this.state.query.searchFields.map(function (sf) {
-				return searchFieldsToMerge.map(function (sfm) {
-					return sfm.field;
-				}).indexOf(sf.field) > -1 ? _extends({}, sf, { value: searchFieldsToMerge.find(function (sfm) {
-						return sfm.field === sf.field;
-					}).value }) : sf;
-			});
+      this.state.query.searchFields = this.state.query.searchFields.map(function (sf) {
+        return searchFieldsToMerge.map(function (sfm) {
+          return sfm.field;
+        }).indexOf(sf.field) > -1 ? _extends({}, sf, { value: searchFieldsToMerge.find(function (sfm) {
+            return sfm.field === sf.field;
+          }).value }) : sf;
+      });
 
-			this.state.query.sortFields = this.state.query.sortFields.map(function (sf) {
-				return sortFieldsToMerge.map(function (sfm) {
-					return sfm.field;
-				}).indexOf(sf.field) > -1 ? _extends({}, sf, { value: sortFieldsToMerge.find(function (sfm) {
-						return sfm.field === sf.field;
-					}).value }) : sf;
-			});
-		}
-	}, {
-		key: "initialize",
-		value: function initialize() {
-			var query = this.state.query;
-			var pageStrategy = query.pageStrategy;
+      this.state.query.sortFields = this.state.query.sortFields.map(function (sf) {
+        return sortFieldsToMerge.map(function (sfm) {
+          return sfm.field;
+        }).indexOf(sf.field) > -1 ? _extends({}, sf, { value: sortFieldsToMerge.find(function (sfm) {
+            return sfm.field === sf.field;
+          }).value }) : sf;
+      });
+    }
+  }, {
+    key: "initialize",
+    value: function initialize() {
+      var query = this.state.query;
+      var pageStrategy = query.pageStrategy;
 
-			var payload = _extends({ type: "SET_QUERY_FIELDS"
-			}, query, { start: pageStrategy === "paginate" ? 0 : null
-			});
+      var payload = _extends({
+        type: "SET_QUERY_FIELDS"
+      }, query, { start: pageStrategy === "paginate" ? 0 : null
+      });
 
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
 
-			return this;
-		}
-	}, {
-		key: "resetSearchFields",
-		value: function resetSearchFields() {
-			var query = this.state.query;
-			var pageStrategy = query.pageStrategy;
+      return this;
+    }
+  }, {
+    key: "resetSearchFields",
+    value: function resetSearchFields() {
+      var query = this.state.query;
+      var pageStrategy = query.pageStrategy;
 
-			var payload = _extends({ type: "SET_QUERY_FIELDS"
-			}, this.settings, { start: pageStrategy === "paginate" ? 0 : null
-			});
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "sendQuery",
-		value: function sendQuery() {
-			var _this = this;
+      var payload = _extends({
+        type: "SET_QUERY_FIELDS"
+      }, this.settings, { start: pageStrategy === "paginate" ? 0 : null
+      });
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+    }
+  }, {
+    key: "sendQuery",
+    value: function sendQuery() {
+      var _this = this;
 
-			var query = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.state.query;
+      var query = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.state.query;
 
-			delete query.cursorMark;
-			this.state.query = query;
-			_server2.default.submitQuery(query, function (action) {
-				_this.state.results = (0, _results2.default)(_this.state.results, action);
-				_this.state.query = (0, _query2.default)(_this.state.query, action);
-				_this.onChange(_this.state, _this.getHandlers());
-			});
-		}
-	}, {
-		key: "sendNextCursorQuery",
-		value: function sendNextCursorQuery() {
-			var _this2 = this;
+      delete query.cursorMark;
+      this.state.query = query;
+      _server2.default.submitQuery(query, function (action) {
+        _this.state.results = (0, _results2.default)(_this.state.results, action);
+        _this.state.query = (0, _query2.default)(_this.state.query, action);
+        _this.onChange(_this.state, _this.getHandlers());
+      });
+    }
+  }, {
+    key: "setSuggestQuery",
+    value: function setSuggestQuery(query, autocomplete, value) {
+      var searchFields = query.searchFields;
+      // Add the current text field value to the searchFields array.
 
-			_server2.default.submitQuery(this.state.query, function (action) {
-				_this2.state.results = (0, _results2.default)(_this2.state.results, _extends({}, action, {
-					type: action.type === "SET_RESULTS" ? "SET_NEXT_RESULTS" : action.type
-				}));
-				_this2.state.query = (0, _query2.default)(_this2.state.query, action);
-				_this2.onChange(_this2.state, _this2.getHandlers());
-			});
-		}
-	}, {
-		key: "fetchCsv",
-		value: function fetchCsv() {
-			_server2.default.fetchCsv(this.state.query, function (data) {
-				var element = document.createElement("a");
-				element.setAttribute("href", "data:application/csv;charset=utf-8," + encodeURIComponent(data));
-				element.setAttribute("download", "export.csv");
+      var newFields = searchFields.map(function (searchField) {
+        return searchField.field === query.mainQueryField ? _extends({}, searchField, { value: value }) : searchField;
+      });
+      var payload = {
+        type: "SET_SUGGEST_QUERY",
+        suggestQuery: {
+          searchFields: newFields,
+          sortFields: query.sortFields,
+          filters: query.filters,
+          userpass: query.userpass,
+          mainQueryField: query.mainQueryField,
+          start: 0,
+          mode: autocomplete.mode,
+          url: autocomplete.url,
+          rows: autocomplete.suggestionRows,
+          value: value
+        }
+      };
+      this.sendSuggestQuery((0, _suggestQuery2.default)(this.state.suggestQuery, payload));
+    }
+  }, {
+    key: "sendSuggestQuery",
+    value: function sendSuggestQuery() {
+      var _this2 = this;
 
-				element.style.display = "none";
-				document.body.appendChild(element);
+      var suggestQuery = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.state.suggestQuery;
 
-				element.click();
+      this.state.suggestQuery = suggestQuery;
+      _server2.default.submitSuggestQuery(suggestQuery, function (action) {
+        _this2.state.suggestions = (0, _suggestions2.default)(_this2.state.suggestions, action);
+        _this2.state.suggestQuery = (0, _suggestQuery2.default)(_this2.state.suggestQuery, action);
+        _this2.onChange(_this2.state, _this2.getHandlers());
+      });
+    }
+  }, {
+    key: "sendNextCursorQuery",
+    value: function sendNextCursorQuery() {
+      var _this3 = this;
 
-				document.body.removeChild(element);
-			});
-		}
-	}, {
-		key: "setCurrentPage",
-		value: function setCurrentPage(page) {
-			var query = this.state.query;
-			var rows = query.rows;
+      _server2.default.submitQuery(this.state.query, function (action) {
+        _this3.state.results = (0, _results2.default)(_this3.state.results, _extends({}, action, {
+          type: action.type === "SET_RESULTS" ? "SET_NEXT_RESULTS" : action.type
+        }));
+        _this3.state.query = (0, _query2.default)(_this3.state.query, action);
+        _this3.onChange(_this3.state, _this3.getHandlers());
+      });
+    }
+  }, {
+    key: "fetchCsv",
+    value: function fetchCsv() {
+      _server2.default.fetchCsv(this.state.query, function (data) {
+        var element = document.createElement("a");
+        element.setAttribute("href", "data:application/csv;charset=utf-8," + encodeURIComponent(data));
+        element.setAttribute("download", "export.csv");
 
-			var payload = { type: "SET_START", newStart: page * rows };
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "setGroup",
-		value: function setGroup(group) {
-			var payload = { type: "SET_GROUP", group: group };
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "setSearchFieldValue",
-		value: function setSearchFieldValue(field, value) {
-			var query = this.state.query;
-			var searchFields = query.searchFields;
+        element.style.display = "none";
+        document.body.appendChild(element);
 
-			var newFields = searchFields.map(function (searchField) {
-				return searchField.field === field ? _extends({}, searchField, { value: value }) : searchField;
-			});
+        element.click();
 
-			var payload = { type: "SET_SEARCH_FIELDS", newFields: newFields };
+        document.body.removeChild(element);
+      });
+    }
+  }, {
+    key: "setCurrentPage",
+    value: function setCurrentPage(page) {
+      var query = this.state.query;
+      var rows = query.rows;
 
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "setFacetSort",
-		value: function setFacetSort(field, value) {
-			var query = this.state.query;
-			var searchFields = query.searchFields;
+      var payload = { type: "SET_START", newStart: page * rows };
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+    }
+  }, {
+    key: "setGroup",
+    value: function setGroup(group) {
+      var payload = { type: "SET_GROUP", group: group };
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+    }
+  }, {
+    key: "setSearchFieldValue",
+    value: function setSearchFieldValue(field, value) {
+      var query = this.state.query;
+      var searchFields = query.searchFields;
 
-			var newFields = searchFields.map(function (searchField) {
-				return searchField.field === field ? _extends({}, searchField, { facetSort: value }) : searchField;
-			});
+      var newFields = searchFields.map(function (searchField) {
+        return searchField.field === field ? _extends({}, searchField, { value: value }) : searchField;
+      });
 
-			var payload = { type: "SET_SEARCH_FIELDS", newFields: newFields };
+      var payload = { type: "SET_SEARCH_FIELDS", newFields: newFields };
 
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "setSortFieldValue",
-		value: function setSortFieldValue(field, value) {
-			var query = this.state.query;
-			var sortFields = query.sortFields;
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+      // Enable the the autosuggest input to be cleared cleared
+      // but only if autcomplete has been configured.
+      if (Object.hasOwnProperty.call(this.state, "suggestQuery")) {
+        this.state.suggestQuery = (0, _suggestQuery2.default)(this.state.suggestQuery, payload);
+      }
+    }
+  }, {
+    key: "setFacetSort",
+    value: function setFacetSort(field, value) {
+      var query = this.state.query;
+      var searchFields = query.searchFields;
 
-			var newSortFields = sortFields.map(function (sortField) {
-				return sortField.field === field ? _extends({}, sortField, { value: value }) : _extends({}, sortField, { value: null });
-			});
+      var newFields = searchFields.map(function (searchField) {
+        return searchField.field === field ? _extends({}, searchField, { facetSort: value }) : searchField;
+      });
 
-			var payload = { type: "SET_SORT_FIELDS", newSortFields: newSortFields };
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "setFilters",
-		value: function setFilters(filters) {
-			var payload = { type: "SET_FILTERS", newFilters: filters };
-			this.sendQuery((0, _query2.default)(this.state.query, payload));
-		}
-	}, {
-		key: "setCollapse",
-		value: function setCollapse(field, value) {
-			var query = this.state.query;
-			var searchFields = query.searchFields;
+      var payload = { type: "SET_SEARCH_FIELDS", newFields: newFields };
 
-			var newFields = searchFields.map(function (searchField) {
-				return searchField.field === field ? _extends({}, searchField, { collapse: value }) : searchField;
-			});
-			var payload = { type: "SET_SEARCH_FIELDS", newFields: newFields };
-			this.state.query = (0, _query2.default)(this.state.query, payload);
-			this.onChange(this.state, this.getHandlers());
-		}
-	}, {
-		key: "getHandlers",
-		value: function getHandlers() {
-			return {
-				onSortFieldChange: this.setSortFieldValue.bind(this),
-				onSearchFieldChange: this.setSearchFieldValue.bind(this),
-				onFacetSortChange: this.setFacetSort.bind(this),
-				onPageChange: this.setCurrentPage.bind(this),
-				onNextCursorQuery: this.sendNextCursorQuery.bind(this),
-				onSetCollapse: this.setCollapse.bind(this),
-				onNewSearch: this.resetSearchFields.bind(this),
-				onCsvExport: this.fetchCsv.bind(this),
-				onGroupChange: this.setGroup.bind(this)
-			};
-		}
-	}]);
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+    }
+  }, {
+    key: "setSortFieldValue",
+    value: function setSortFieldValue(field, value) {
+      var query = this.state.query;
+      var sortFields = query.sortFields;
 
-	return SolrClient;
+      var newSortFields = sortFields.map(function (sortField) {
+        return sortField.field === field ? _extends({}, sortField, { value: value }) : _extends({}, sortField, { value: null });
+      });
+
+      var payload = { type: "SET_SORT_FIELDS", newSortFields: newSortFields };
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+    }
+  }, {
+    key: "setFilters",
+    value: function setFilters(filters) {
+      var payload = { type: "SET_FILTERS", newFilters: filters };
+      this.sendQuery((0, _query2.default)(this.state.query, payload));
+    }
+  }, {
+    key: "setCollapse",
+    value: function setCollapse(field, value) {
+      var query = this.state.query;
+      var searchFields = query.searchFields;
+
+      var newFields = searchFields.map(function (searchField) {
+        return searchField.field === field ? _extends({}, searchField, { collapse: value }) : searchField;
+      });
+      var payload = { type: "SET_SEARCH_FIELDS", newFields: newFields };
+      this.state.query = (0, _query2.default)(this.state.query, payload);
+      this.onChange(this.state, this.getHandlers());
+    }
+  }, {
+    key: "getHandlers",
+    value: function getHandlers() {
+      return {
+        onTextInputChange: this.setSuggestQuery.bind(this),
+        onSortFieldChange: this.setSortFieldValue.bind(this),
+        onSearchFieldChange: this.setSearchFieldValue.bind(this),
+        onFacetSortChange: this.setFacetSort.bind(this),
+        onPageChange: this.setCurrentPage.bind(this),
+        onNextCursorQuery: this.sendNextCursorQuery.bind(this),
+        onSetCollapse: this.setCollapse.bind(this),
+        onNewSearch: this.resetSearchFields.bind(this),
+        onCsvExport: this.fetchCsv.bind(this),
+        onGroupChange: this.setGroup.bind(this)
+      };
+    }
+  }]);
+
+  return SolrClient;
 }();
 
 exports.SolrClient = SolrClient;
 
-},{"../reducers/query":44,"../reducers/results":45,"./server":19}],21:[function(_dereq_,module,exports){
+},{"../reducers/query":44,"../reducers/results":45,"../reducers/suggestQuery":46,"../reducers/suggestions":47,"./server":19}],21:[function(_dereq_,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -1934,245 +2010,300 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var rangeFacetToQueryFilter = function rangeFacetToQueryFilter(field) {
-	var filters = field.value || [];
-	if (filters.length < 2) {
-		return null;
-	}
+  var filters = field.value || [];
+  if (filters.length < 2) {
+    return null;
+  }
 
-	return encodeURIComponent(field.field + ":[" + filters[0] + " TO " + filters[1] + "]");
+  return encodeURIComponent(field.field + ":[" + filters[0] + " TO " + filters[1] + "]");
 };
 
 var periodRangeFacetToQueryFilter = function periodRangeFacetToQueryFilter(field) {
-	var filters = field.value || [];
-	if (filters.length < 2) {
-		return null;
-	}
+  var filters = field.value || [];
+  if (filters.length < 2) {
+    return null;
+  }
 
-	return encodeURIComponent(field.lowerBound + ":[" + filters[0] + " TO " + filters[1] + "] OR " + (field.upperBound + ":[" + filters[0] + " TO " + filters[1] + "] OR ") + ("(" + field.lowerBound + ":[* TO " + filters[0] + "] AND " + field.upperBound + ":[" + filters[1] + " TO *])"));
+  return encodeURIComponent(field.lowerBound + ":[" + filters[0] + " TO " + filters[1] + "] OR " + (field.upperBound + ":[" + filters[0] + " TO " + filters[1] + "] OR ") + ("(" + field.lowerBound + ":[* TO " + filters[0] + "] AND " + field.upperBound + ":[" + filters[1] + " TO *])"));
 };
 
 var listFacetFieldToQueryFilter = function listFacetFieldToQueryFilter(field) {
-	var filters = field.value || [];
-	if (filters.length === 0) {
-		return null;
-	}
+  var filters = field.value || [];
+  if (filters.length === 0) {
+    return null;
+  }
 
-	var filterQ = filters.map(function (f) {
-		return "\"" + f + "\"";
-	}).join(" OR ");
-	return encodeURIComponent(field.field + ":(" + filterQ + ")");
+  var filterQ = filters.map(function (f) {
+    return "\"" + f + "\"";
+  }).join(" OR ");
+  return encodeURIComponent(field.field + ":(" + filterQ + ")");
 };
 
 var textFieldToQueryFilter = function textFieldToQueryFilter(field) {
-	if (!field.value || field.value.length === 0) {
-		return null;
-	}
+  if (!field.value || field.value.length === 0) {
+    return null;
+  }
 
-	return encodeURIComponent(field.field === "*" ? field.value : field.field + ":" + field.value);
+  return encodeURIComponent(field.field === "*" ? field.value : field.field + ":" + field.value);
 };
 
 var fieldToQueryFilter = function fieldToQueryFilter(field) {
-	if (field.type === "text") {
-		return textFieldToQueryFilter(field);
-	} else if (field.type === "list-facet") {
-		return listFacetFieldToQueryFilter(field);
-	} else if (field.type === "range-facet" || field.type === "range") {
-		return rangeFacetToQueryFilter(field);
-	} else if (field.type === "period-range-facet" || field.type === "period-range") {
-		return periodRangeFacetToQueryFilter(field);
-	}
-	return null;
+  if (field.type === "text") {
+    return textFieldToQueryFilter(field);
+  } else if (field.type === "list-facet") {
+    return listFacetFieldToQueryFilter(field);
+  } else if (field.type === "range-facet" || field.type === "range") {
+    return rangeFacetToQueryFilter(field);
+  } else if (field.type === "period-range-facet" || field.type === "period-range") {
+    return periodRangeFacetToQueryFilter(field);
+  }
+  return null;
 };
 
 var buildQuery = function buildQuery(fields, mainQueryField) {
-	return fields
-	// Do not include main query field in filter field query param.
-	.filter(function (searchField) {
-		return !Object.hasOwnProperty.call(searchField, "field") || Object.hasOwnProperty.call(searchField, "field") && searchField.field !== mainQueryField;
-	}).map(fieldToQueryFilter).filter(function (queryFilter) {
-		return queryFilter !== null;
-	}).map(function (queryFilter) {
-		return "fq=" + queryFilter;
-	}).join("&");
+  return fields
+  // Do not include main query field in filter field query param.
+  .filter(function (searchField) {
+    return !Object.hasOwnProperty.call(searchField, "field") || Object.hasOwnProperty.call(searchField, "field") && searchField.field !== mainQueryField;
+  }).map(fieldToQueryFilter).filter(function (queryFilter) {
+    return queryFilter !== null;
+  }).map(function (queryFilter) {
+    return "fq=" + queryFilter;
+  }).join("&");
 };
 
 var facetFields = function facetFields(fields) {
-	return fields.filter(function (field) {
-		return field.type === "list-facet" || field.type === "range-facet";
-	}).map(function (field) {
-		return "facet.field=" + encodeURIComponent(field.field);
-	}).concat(fields.filter(function (field) {
-		return field.type === "period-range-facet";
-	}).map(function (field) {
-		return "facet.field=" + encodeURIComponent(field.lowerBound) + "&facet.field=" + encodeURIComponent(field.upperBound);
-	})).join("&");
+  return fields.filter(function (field) {
+    return field.type === "list-facet" || field.type === "range-facet";
+  }).map(function (field) {
+    return "facet.field=" + encodeURIComponent(field.field);
+  }).concat(fields.filter(function (field) {
+    return field.type === "period-range-facet";
+  }).map(function (field) {
+    return "facet.field=" + encodeURIComponent(field.lowerBound) + "&facet.field=" + encodeURIComponent(field.upperBound);
+  })).join("&");
 };
 
 var facetSorts = function facetSorts(fields) {
-	return fields.filter(function (field) {
-		return field.facetSort;
-	}).map(function (field) {
-		return "f." + encodeURIComponent(field.field) + ".facet.sort=" + field.facetSort;
-	}).join("&");
+  return fields.filter(function (field) {
+    return field.facetSort;
+  }).map(function (field) {
+    return "f." + encodeURIComponent(field.field) + ".facet.sort=" + field.facetSort;
+  }).join("&");
 };
 
 var buildSort = function buildSort(sortFields) {
-	return sortFields.filter(function (sortField) {
-		return sortField.value;
-	}).map(function (sortField) {
-		return encodeURIComponent(sortField.field + " " + sortField.value);
-	}).join(",");
+  return sortFields.filter(function (sortField) {
+    return sortField.value;
+  }).map(function (sortField) {
+    return encodeURIComponent(sortField.field + " " + sortField.value);
+  }).join(",");
 };
 
 var buildFormat = function buildFormat(format) {
-	return Object.keys(format).map(function (key) {
-		return key + "=" + encodeURIComponent(format[key]);
-	}).join("&");
+  return Object.keys(format).map(function (key) {
+    return key + "=" + encodeURIComponent(format[key]);
+  }).join("&");
 };
 
 var buildMainQuery = function buildMainQuery(fields, mainQueryField) {
-	var qs = "q=";
-	var params = fields.filter(function (searchField) {
-		return searchField.field === mainQueryField;
-	}).map(function (searchField) {
-		return fieldToQueryFilter(searchField);
-	});
-	// If there are multiple main query fields, join them.
-	if (params.length > 1) {
-		qs += params.join("&");
-	}
-	// If there is only one main query field, add only it.
-	else if (params.length === 1) {
-			qs += params[0];
-		}
-		// If there are no main query fields, send the wildcard query.
-		else {
-				qs += "*:*";
-			}
-	return qs;
+  var qs = "q=";
+  var params = fields.filter(function (searchField) {
+    return searchField.field === mainQueryField;
+  }).map(function (searchField) {
+    return fieldToQueryFilter(searchField);
+  });
+  // If there are multiple main query fields, join them.
+  if (params.length > 1) {
+    qs += params.join("&");
+  }
+  // If there is only one main query field, add only it.
+  else if (params.length === 1) {
+      if (params[0] !== null) {
+        qs += params[0];
+      } else {
+        // If query field exists but is null send the wildcard query.
+        qs += "*:*";
+      }
+    }
+    // If there are no main query fields, send the wildcard query.
+    else {
+        qs += "*:*";
+      }
+  return qs;
 };
 
 var buildHighlight = function buildHighlight(highlight) {
-	var hlQs = "";
-	// If highlight is set, then populate params from keys/values.
-	if (highlight !== null && (typeof highlight === "undefined" ? "undefined" : _typeof(highlight)) === "object") {
-		var hlParams = "&hl=on";
+  var hlQs = "";
+  // If highlight is set, then populate params from keys/values.
+  if (highlight !== null && (typeof highlight === "undefined" ? "undefined" : _typeof(highlight)) === "object") {
+    var hlParams = "hl=on";
 
-		var _iteratorNormalCompletion = true;
-		var _didIteratorError = false;
-		var _iteratorError = undefined;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
 
-		try {
-			for (var _iterator = Object.keys(highlight)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-				var key = _step.value;
+    try {
+      for (var _iterator = Object.keys(highlight)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        var key = _step.value;
 
-				// Support nested objects like hl.simple.tags
-				if (_typeof(highlight[key]) === "object") {
-					var _iteratorNormalCompletion2 = true;
-					var _didIteratorError2 = false;
-					var _iteratorError2 = undefined;
+        // Support nested objects like hl.simple.tags
+        if (_typeof(highlight[key]) === "object") {
+          var _iteratorNormalCompletion2 = true;
+          var _didIteratorError2 = false;
+          var _iteratorError2 = undefined;
 
-					try {
-						for (var _iterator2 = Object.keys(highlight[key])[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-							var nestedKey = _step2.value;
+          try {
+            for (var _iterator2 = Object.keys(highlight[key])[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+              var nestedKey = _step2.value;
 
-							hlParams += "&hl." + key + "." + nestedKey + "=" + highlight[key][nestedKey];
-						}
-					} catch (err) {
-						_didIteratorError2 = true;
-						_iteratorError2 = err;
-					} finally {
-						try {
-							if (!_iteratorNormalCompletion2 && _iterator2.return) {
-								_iterator2.return();
-							}
-						} finally {
-							if (_didIteratorError2) {
-								throw _iteratorError2;
-							}
-						}
-					}
-				}
-				// Support flat key/values like hl.fl=my_field_name
-				else {
-						hlParams += "&hl." + key + "=" + highlight[key];
-					}
-			}
-		} catch (err) {
-			_didIteratorError = true;
-			_iteratorError = err;
-		} finally {
-			try {
-				if (!_iteratorNormalCompletion && _iterator.return) {
-					_iterator.return();
-				}
-			} finally {
-				if (_didIteratorError) {
-					throw _iteratorError;
-				}
-			}
-		}
+              hlParams += "&hl." + key + "." + nestedKey + "=" + encodeURIComponent(highlight[key][nestedKey]);
+            }
+          } catch (err) {
+            _didIteratorError2 = true;
+            _iteratorError2 = err;
+          } finally {
+            try {
+              if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                _iterator2.return();
+              }
+            } finally {
+              if (_didIteratorError2) {
+                throw _iteratorError2;
+              }
+            }
+          }
+        }
+        // Support flat key/values like hl.fl=my_field_name
+        else {
+            hlParams += "&hl." + key + "=" + encodeURIComponent(highlight[key]);
+          }
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
+    }
 
-		hlQs = hlParams;
-	}
-	return hlQs;
+    hlQs = hlParams;
+  }
+  return hlQs;
 };
 
 var solrQuery = function solrQuery(query) {
-	var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { wt: "json" };
-	var searchFields = query.searchFields,
-	    sortFields = query.sortFields,
-	    rows = query.rows,
-	    start = query.start,
-	    facetLimit = query.facetLimit,
-	    facetSort = query.facetSort,
-	    pageStrategy = query.pageStrategy,
-	    cursorMark = query.cursorMark,
-	    idField = query.idField,
-	    group = query.group,
-	    hl = query.hl;
+  var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { wt: "json" };
+  var searchFields = query.searchFields,
+      sortFields = query.sortFields,
+      rows = query.rows,
+      start = query.start,
+      facetLimit = query.facetLimit,
+      facetSort = query.facetSort,
+      pageStrategy = query.pageStrategy,
+      cursorMark = query.cursorMark,
+      idField = query.idField,
+      group = query.group,
+      hl = query.hl;
 
 
-	var mainQueryField = Object.hasOwnProperty.call(query, "mainQueryField") ? query.mainQueryField : "";
+  var mainQueryField = Object.hasOwnProperty.call(query, "mainQueryField") ? query.mainQueryField : null;
 
-	var filters = (query.filters || []).map(function (filter) {
-		return _extends({}, filter, { type: filter.type || "text" });
-	});
-	var mainQuery = buildMainQuery(searchFields.concat(filters), mainQueryField);
-	var queryParams = buildQuery(searchFields.concat(filters), mainQueryField);
+  var filters = (query.filters || []).map(function (filter) {
+    return _extends({}, filter, { type: filter.type || "text" });
+  });
+  var mainQuery = buildMainQuery(searchFields.concat(filters), mainQueryField);
+  var queryParams = buildQuery(searchFields.concat(filters), mainQueryField);
 
-	var facetFieldParam = facetFields(searchFields);
-	var facetSortParams = facetSorts(searchFields);
-	var facetLimitParam = "facet.limit=" + (facetLimit || -1);
-	var facetSortParam = "facet.sort=" + (facetSort || "index");
+  var facetFieldParam = facetFields(searchFields);
+  var facetSortParams = facetSorts(searchFields);
+  var facetLimitParam = "facet.limit=" + (facetLimit || -1);
+  var facetSortParam = "facet.sort=" + (facetSort || "index");
 
-	var cursorMarkParam = pageStrategy === "cursor" ? "cursorMark=" + encodeURIComponent(cursorMark || "*") : "";
-	var idSort = pageStrategy === "cursor" ? [{ field: idField, value: "asc" }] : [];
+  var cursorMarkParam = pageStrategy === "cursor" ? "cursorMark=" + encodeURIComponent(cursorMark || "*") : "";
+  var idSort = pageStrategy === "cursor" ? [{ field: idField, value: "asc" }] : [];
 
-	var sortParam = buildSort(sortFields.concat(idSort));
-	var groupParam = group && group.field ? "group=on&group.field=" + encodeURIComponent(group.field) : "";
-	var highlightParam = buildHighlight(hl);
+  var sortParam = buildSort(sortFields.concat(idSort));
+  var groupParam = group && group.field ? "group=on&group.field=" + encodeURIComponent(group.field) : "";
+  var highlightParam = buildHighlight(hl);
 
-	return mainQuery + ("&" + (queryParams.length > 0 ? queryParams : "")) + ("" + (sortParam.length > 0 ? "&sort=" + sortParam : "")) + ("" + (facetFieldParam.length > 0 ? "&" + facetFieldParam : "")) + ("" + (facetSortParams.length > 0 ? "&" + facetSortParams : "")) + ("" + (groupParam.length > 0 ? "&" + groupParam : "")) + ("&rows=" + rows) + ("&" + facetLimitParam) + ("&" + facetSortParam) + ("&" + cursorMarkParam) + (start === null ? "" : "&start=" + start) + "&facet=on" + ("&" + buildFormat(format)) + ("" + highlightParam);
+  return mainQuery + ("" + (queryParams.length > 0 ? "&" + queryParams : "")) + ("" + (sortParam.length > 0 ? "&sort=" + sortParam : "")) + ("" + (facetFieldParam.length > 0 ? "&" + facetFieldParam : "")) + ("" + (facetSortParams.length > 0 ? "&" + facetSortParams : "")) + ("" + (groupParam.length > 0 ? "&" + groupParam : "")) + ("&rows=" + rows) + ("&" + facetLimitParam) + ("&" + facetSortParam) + ("&" + cursorMarkParam) + (start === null ? "" : "&start=" + start) + "&facet=on" + (highlightParam === "" ? "" : "&" + highlightParam) + ("&" + buildFormat(format));
 };
 
 exports.default = solrQuery;
+
+
+var buildSuggestQuery = function buildSuggestQuery(fields, suggestQueryField) {
+  var qs = "q=";
+  var params = fields.filter(function (searchField) {
+    return searchField.field === suggestQueryField;
+  }).map(function (searchField) {
+    // To support search-as-you-type we add a wildcard to match zero or more
+    // additional characters at the end of the users search term.
+    // @see: https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html#TheStandardQueryParser-WildcardSearches
+    // @see: https://opensourceconnections.com/blog/2013/06/07/search-as-you-type-with-solr/
+    // We also set the default field to the suggestQueryField.
+    return searchField.value !== "" ? searchField.value + "+" + searchField.value + "*&df=" + searchField.field : "";
+  });
+  // If there are multiple suggest query fields, join them.
+  if (params.length > 1) {
+    qs += params.join("&");
+  }
+  // If there is only one suggest query field, add only it.
+  else if (params.length === 1) {
+      if (params[0] !== null) {
+        qs += params[0];
+      }
+    }
+  return qs;
+};
+
+var solrSuggestQuery = function solrSuggestQuery(suggestQuery) {
+  var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { wt: "json" };
+  var rows = suggestQuery.rows,
+      searchFields = suggestQuery.searchFields,
+      filters = suggestQuery.filters;
+
+
+  var mainQueryField = Object.hasOwnProperty.call(suggestQuery, "mainQueryField") ? suggestQuery.mainQueryField : null;
+
+  var queryFilters = (filters || []).map(function (filter) {
+    return _extends({}, filter, { type: filter.type || "text" });
+  });
+  var mainQuery = buildSuggestQuery(searchFields.concat(queryFilters), mainQueryField);
+  var queryParams = buildQuery(searchFields.concat(queryFilters), mainQueryField);
+  var facetFieldParam = facetFields(searchFields);
+
+  return mainQuery + ("" + (queryParams.length > 0 ? "&" + queryParams : "")) + ("" + (facetFieldParam.length > 0 ? "&" + facetFieldParam : "")) + ("&rows=" + rows) + ("&" + buildFormat(format));
+};
+
 exports.rangeFacetToQueryFilter = rangeFacetToQueryFilter;
 exports.periodRangeFacetToQueryFilter = periodRangeFacetToQueryFilter;
 exports.listFacetFieldToQueryFilter = listFacetFieldToQueryFilter;
 exports.textFieldToQueryFilter = textFieldToQueryFilter;
 exports.fieldToQueryFilter = fieldToQueryFilter;
 exports.buildQuery = buildQuery;
+exports.buildMainQuery = buildMainQuery;
+exports.buildSuggestQuery = buildSuggestQuery;
+exports.buildHighlight = buildHighlight;
 exports.facetFields = facetFields;
 exports.facetSorts = facetSorts;
 exports.buildSort = buildSort;
 exports.solrQuery = solrQuery;
+exports.solrSuggestQuery = solrSuggestQuery;
 
 },{}],22:[function(_dereq_,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _result = _dereq_("./results/result");
@@ -2238,35 +2369,35 @@ var _currentQuery2 = _interopRequireDefault(_currentQuery);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = {
-	searchFields: {
-		text: _textSearch2.default,
-		"list-facet": _listFacet2.default,
-		"range-facet": _rangeFacet2.default,
-		"period-range-facet": _rangeFacet2.default,
-		container: _searchFieldContainer2.default,
-		currentQuery: _currentQuery2.default
-	},
-	results: {
-		result: _result2.default,
-		resultCount: _countLabel2.default,
-		header: _header2.default,
-		list: _list2.default,
-		container: _container2.default,
-		pending: _pending2.default,
-		preloadIndicator: _preloadIndicator2.default,
-		csvExport: _csvExport2.default,
-		paginate: _pagination2.default
-	},
-	sortFields: {
-		menu: _sortMenu2.default
-	}
+  searchFields: {
+    text: _textSearch2.default,
+    "list-facet": _listFacet2.default,
+    "range-facet": _rangeFacet2.default,
+    "period-range-facet": _rangeFacet2.default,
+    container: _searchFieldContainer2.default,
+    currentQuery: _currentQuery2.default
+  },
+  results: {
+    result: _result2.default,
+    resultCount: _countLabel2.default,
+    header: _header2.default,
+    list: _list2.default,
+    container: _container2.default,
+    pending: _pending2.default,
+    preloadIndicator: _preloadIndicator2.default,
+    csvExport: _csvExport2.default,
+    paginate: _pagination2.default
+  },
+  sortFields: {
+    menu: _sortMenu2.default
+  }
 };
 
 },{"./current-query":23,"./list-facet":27,"./range-facet":28,"./results/container":30,"./results/count-label":31,"./results/csv-export":32,"./results/header":33,"./results/list":34,"./results/pagination":35,"./results/pending":36,"./results/preload-indicator":37,"./results/result":38,"./search-field-container":39,"./sort-menu":41,"./text-search":42}],23:[function(_dereq_,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -2292,175 +2423,175 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var CurrentQuery = function (_React$Component) {
-	_inherits(CurrentQuery, _React$Component);
+  _inherits(CurrentQuery, _React$Component);
 
-	function CurrentQuery() {
-		_classCallCheck(this, CurrentQuery);
+  function CurrentQuery() {
+    _classCallCheck(this, CurrentQuery);
 
-		return _possibleConstructorReturn(this, (CurrentQuery.__proto__ || Object.getPrototypeOf(CurrentQuery)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (CurrentQuery.__proto__ || Object.getPrototypeOf(CurrentQuery)).apply(this, arguments));
+  }
 
-	_createClass(CurrentQuery, [{
-		key: "removeListFacetValue",
-		value: function removeListFacetValue(field, values, value) {
-			var foundIdx = values.indexOf(value);
-			if (foundIdx > -1) {
-				this.props.onChange(field, values.filter(function (v, i) {
-					return i !== foundIdx;
-				}));
-			}
-		}
-	}, {
-		key: "removeRangeFacetValue",
-		value: function removeRangeFacetValue(field) {
-			this.props.onChange(field, []);
-		}
-	}, {
-		key: "removeTextValue",
-		value: function removeTextValue(field) {
-			this.props.onChange(field, "");
-		}
-	}, {
-		key: "renderFieldValues",
-		value: function renderFieldValues(searchField) {
-			var _this2 = this;
+  _createClass(CurrentQuery, [{
+    key: "removeListFacetValue",
+    value: function removeListFacetValue(field, values, value) {
+      var foundIdx = values.indexOf(value);
+      if (foundIdx > -1) {
+        this.props.onChange(field, values.filter(function (v, i) {
+          return i !== foundIdx;
+        }));
+      }
+    }
+  }, {
+    key: "removeRangeFacetValue",
+    value: function removeRangeFacetValue(field) {
+      this.props.onChange(field, []);
+    }
+  }, {
+    key: "removeTextValue",
+    value: function removeTextValue(field) {
+      this.props.onChange(field, "");
+    }
+  }, {
+    key: "renderFieldValues",
+    value: function renderFieldValues(searchField) {
+      var _this2 = this;
 
-			var bootstrapCss = this.props.bootstrapCss;
-
-
-			switch (searchField.type) {
-				case "list-facet":
-					return searchField.value.map(function (val, i) {
-						return _react2.default.createElement(
-							"span",
-							{ className: (0, _classnames2.default)({ "label": bootstrapCss, "label-default": bootstrapCss }), key: i,
-								onClick: function onClick() {
-									return _this2.removeListFacetValue(searchField.field, searchField.value, val);
-								} },
-							val,
-							_react2.default.createElement(
-								"a",
-								null,
-								bootstrapCss ? _react2.default.createElement("span", { className: "glyphicon glyphicon-remove-sign" }) : "❌"
-							)
-						);
-					});
-
-				case "range-facet":
-					return _react2.default.createElement(
-						"span",
-						{ className: (0, _classnames2.default)({ "label": bootstrapCss, "label-default": bootstrapCss }),
-							onClick: function onClick() {
-								return _this2.removeRangeFacetValue(searchField.field);
-							} },
-						searchField.value[0],
-						" - ",
-						searchField.value[1],
-						_react2.default.createElement(
-							"a",
-							null,
-							bootstrapCss ? _react2.default.createElement("span", { className: "glyphicon glyphicon-remove-sign" }) : "❌"
-						)
-					);
-
-				case "text":
-					return _react2.default.createElement(
-						"span",
-						{ className: (0, _classnames2.default)({ "label": bootstrapCss, "label-default": bootstrapCss }),
-							onClick: function onClick() {
-								return _this2.removeTextValue(searchField.field);
-							} },
-						searchField.value,
-						_react2.default.createElement(
-							"a",
-							null,
-							bootstrapCss ? _react2.default.createElement("span", { className: "glyphicon glyphicon-remove-sign" }) : "❌"
-						)
-					);
-			}
-			return null;
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _this3 = this;
-
-			var _props = this.props,
-			    bootstrapCss = _props.bootstrapCss,
-			    query = _props.query;
+      var bootstrapCss = this.props.bootstrapCss;
 
 
-			var splitFields = query.searchFields.filter(function (searchField) {
-				return searchField.value && searchField.value.length > 0;
-			}).map(function (searchField, i) {
-				return i % 2 === 0 ? { type: "odds", searchField: searchField } : { type: "evens", searchField: searchField };
-			});
+      switch (searchField.type) {
+        case "list-facet":
+          return searchField.value.map(function (val, i) {
+            return _react2.default.createElement(
+              "span",
+              { className: (0, _classnames2.default)({ "label": bootstrapCss, "label-default": bootstrapCss }), key: i,
+                onClick: function onClick() {
+                  return _this2.removeListFacetValue(searchField.field, searchField.value, val);
+                } },
+              val,
+              _react2.default.createElement(
+                "a",
+                null,
+                bootstrapCss ? _react2.default.createElement("span", { className: "glyphicon glyphicon-remove-sign" }) : "❌"
+              )
+            );
+          });
 
-			var odds = splitFields.filter(function (sf) {
-				return sf.type === "evens";
-			}).map(function (sf) {
-				return sf.searchField;
-			});
-			var evens = splitFields.filter(function (sf) {
-				return sf.type === "odds";
-			}).map(function (sf) {
-				return sf.searchField;
-			});
+        case "range-facet":
+          return _react2.default.createElement(
+            "span",
+            { className: (0, _classnames2.default)({ "label": bootstrapCss, "label-default": bootstrapCss }),
+              onClick: function onClick() {
+                return _this2.removeRangeFacetValue(searchField.field);
+              } },
+            searchField.value[0],
+            " - ",
+            searchField.value[1],
+            _react2.default.createElement(
+              "a",
+              null,
+              bootstrapCss ? _react2.default.createElement("span", { className: "glyphicon glyphicon-remove-sign" }) : "❌"
+            )
+          );
 
-			if (odds.length === 0 && evens.length === 0) {
-				return null;
-			}
+        case "text":
+          return _react2.default.createElement(
+            "span",
+            { className: (0, _classnames2.default)({ "label": bootstrapCss, "label-default": bootstrapCss }),
+              onClick: function onClick() {
+                return _this2.removeTextValue(searchField.field);
+              } },
+            searchField.value,
+            _react2.default.createElement(
+              "a",
+              null,
+              bootstrapCss ? _react2.default.createElement("span", { className: "glyphicon glyphicon-remove-sign" }) : "❌"
+            )
+          );
+      }
+      return null;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this3 = this;
 
-			return _react2.default.createElement(
-				"div",
-				{ className: (0, _classnames2.default)("current-query", { "panel-body": bootstrapCss }) },
-				_react2.default.createElement(
-					"div",
-					{ className: (0, _classnames2.default)({ "row": bootstrapCss }) },
-					_react2.default.createElement(
-						"ul",
-						{ className: (0, _classnames2.default)({ "col-md-6": bootstrapCss }) },
-						evens.map(function (searchField, i) {
-							return _react2.default.createElement(
-								"li",
-								{ className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), key: i },
-								_react2.default.createElement(
-									"label",
-									null,
-									searchField.label
-								),
-								_this3.renderFieldValues(searchField)
-							);
-						})
-					),
-					_react2.default.createElement(
-						"ul",
-						{ className: (0, _classnames2.default)({ "col-md-6": bootstrapCss }) },
-						odds.map(function (searchField, i) {
-							return _react2.default.createElement(
-								"li",
-								{ className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), key: i },
-								_react2.default.createElement(
-									"label",
-									null,
-									searchField.label
-								),
-								_this3.renderFieldValues(searchField)
-							);
-						})
-					)
-				)
-			);
-		}
-	}]);
+      var _props = this.props,
+          bootstrapCss = _props.bootstrapCss,
+          query = _props.query;
 
-	return CurrentQuery;
+
+      var splitFields = query.searchFields.filter(function (searchField) {
+        return searchField.value && searchField.value.length > 0;
+      }).map(function (searchField, i) {
+        return i % 2 === 0 ? { type: "odds", searchField: searchField } : { type: "evens", searchField: searchField };
+      });
+
+      var odds = splitFields.filter(function (sf) {
+        return sf.type === "evens";
+      }).map(function (sf) {
+        return sf.searchField;
+      });
+      var evens = splitFields.filter(function (sf) {
+        return sf.type === "odds";
+      }).map(function (sf) {
+        return sf.searchField;
+      });
+
+      if (odds.length === 0 && evens.length === 0) {
+        return null;
+      }
+
+      return _react2.default.createElement(
+        "div",
+        { className: (0, _classnames2.default)("current-query", { "panel-body": bootstrapCss }) },
+        _react2.default.createElement(
+          "div",
+          { className: (0, _classnames2.default)({ "row": bootstrapCss }) },
+          _react2.default.createElement(
+            "ul",
+            { className: (0, _classnames2.default)({ "col-md-6": bootstrapCss }) },
+            evens.map(function (searchField, i) {
+              return _react2.default.createElement(
+                "li",
+                { className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), key: i },
+                _react2.default.createElement(
+                  "label",
+                  null,
+                  searchField.label
+                ),
+                _this3.renderFieldValues(searchField)
+              );
+            })
+          ),
+          _react2.default.createElement(
+            "ul",
+            { className: (0, _classnames2.default)({ "col-md-6": bootstrapCss }) },
+            odds.map(function (searchField, i) {
+              return _react2.default.createElement(
+                "li",
+                { className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), key: i },
+                _react2.default.createElement(
+                  "label",
+                  null,
+                  searchField.label
+                ),
+                _this3.renderFieldValues(searchField)
+              );
+            })
+          )
+        )
+      );
+    }
+  }]);
+
+  return CurrentQuery;
 }(_react2.default.Component);
 
 CurrentQuery.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	onChange: _propTypes2.default.func,
-	query: _propTypes2.default.object
+  bootstrapCss: _propTypes2.default.bool,
+  onChange: _propTypes2.default.func,
+  query: _propTypes2.default.object
 };
 
 exports.default = CurrentQuery;
@@ -2469,7 +2600,7 @@ exports.default = CurrentQuery;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -2491,40 +2622,42 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var CheckedIcon = function (_React$Component) {
-	_inherits(CheckedIcon, _React$Component);
+  _inherits(CheckedIcon, _React$Component);
 
-	function CheckedIcon() {
-		_classCallCheck(this, CheckedIcon);
+  function CheckedIcon() {
+    _classCallCheck(this, CheckedIcon);
 
-		return _possibleConstructorReturn(this, (CheckedIcon.__proto__ || Object.getPrototypeOf(CheckedIcon)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (CheckedIcon.__proto__ || Object.getPrototypeOf(CheckedIcon)).apply(this, arguments));
+  }
 
-	_createClass(CheckedIcon, [{
-		key: "render",
-		value: function render() {
-			var title = this.props.title != null ? _react2.default.createElement(
-				"title",
-				null,
-				this.props.title
-			) : null;
+  _createClass(CheckedIcon, [{
+    key: "render",
+    value: function render() {
+      var title = this.props.title != null ? _react2.default.createElement(
+        "title",
+        null,
+        this.props.title
+      ) : null;
 
-			return _react2.default.createElement(
-				"svg",
-				{ className: "checkbox-icon checked", viewBox: "0 0 489 402", width: "10" },
-				title,
-				_react2.default.createElement("path", { d: "M 377.87,24.128 C 361.786,8.044 342.417,0.002 319.769,0.002 H 82.227 C 59.579,0.002 40.211,8.044 24.125,24.128 8.044,40.214 0.002,59.578 0.002,82.23 v 237.543 c 0,22.647 8.042,42.014 24.123,58.101 16.086,16.085 35.454,24.127 58.102,24.127 h 237.542 c 22.648,0 42.011,-8.042 58.102,-24.127 16.085,-16.087 24.126,-35.453 24.126,-58.101 V 82.23 C 401.993,59.582 393.951,40.214 377.87,24.128 z m -12.422,295.645 c 0,12.559 -4.47,23.314 -13.415,32.264 -8.945,8.945 -19.698,13.411 -32.265,13.411 H 82.227 c -12.563,0 -23.317,-4.466 -32.264,-13.411 -8.945,-8.949 -13.418,-19.705 -13.418,-32.264 V 82.23 c 0,-12.562 4.473,-23.316 13.418,-32.264 C 58.91,41.02 69.664,36.548 82.227,36.548 h 237.542 c 12.566,0 23.319,4.473 32.265,13.418 8.945,8.947 13.415,19.701 13.415,32.264 v 237.543 l -0.001,0 z" }),
-				_react2.default.createElement("path", { d: "M 480.59183,75.709029 442.06274,38.831006 c -5.28301,-5.060423 -11.70817,-7.591583 -19.26056,-7.591583 -7.55937,0 -13.98453,2.53116 -19.26753,7.591583 L 217.6825,216.98773 134.38968,136.99258 c -5.28896,-5.06231 -11.71015,-7.59062 -19.26256,-7.59062 -7.55736,0 -13.97854,2.52831 -19.267516,7.59062 l -38.529082,36.87898 c -5.28897,5.06136 -7.932461,11.20929 -7.932461,18.44186 0,7.22686 2.643491,13.38049 7.932461,18.4409 l 102.555358,98.15873 38.53207,36.87803 c 5.28598,5.06421 11.70916,7.59253 19.26455,7.59253 7.5524,0 13.97558,-2.53496 19.26454,-7.59253 l 38.53107,-36.87803 205.11372,-196.32314 c 5.284,-5.06232 7.93246,-11.20929 7.93246,-18.441873 0.005,-7.228765 -2.64846,-13.376685 -7.93246,-18.439008 z" })
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "svg",
+        { className: "checkbox-icon checked", viewBox: "0 0 489 402", width: "10" },
+        title,
+        _react2.default.createElement("path", {
+          d: "M 377.87,24.128 C 361.786,8.044 342.417,0.002 319.769,0.002 H 82.227 C 59.579,0.002 40.211,8.044 24.125,24.128 8.044,40.214 0.002,59.578 0.002,82.23 v 237.543 c 0,22.647 8.042,42.014 24.123,58.101 16.086,16.085 35.454,24.127 58.102,24.127 h 237.542 c 22.648,0 42.011,-8.042 58.102,-24.127 16.085,-16.087 24.126,-35.453 24.126,-58.101 V 82.23 C 401.993,59.582 393.951,40.214 377.87,24.128 z m -12.422,295.645 c 0,12.559 -4.47,23.314 -13.415,32.264 -8.945,8.945 -19.698,13.411 -32.265,13.411 H 82.227 c -12.563,0 -23.317,-4.466 -32.264,-13.411 -8.945,-8.949 -13.418,-19.705 -13.418,-32.264 V 82.23 c 0,-12.562 4.473,-23.316 13.418,-32.264 C 58.91,41.02 69.664,36.548 82.227,36.548 h 237.542 c 12.566,0 23.319,4.473 32.265,13.418 8.945,8.947 13.415,19.701 13.415,32.264 v 237.543 l -0.001,0 z" }),
+        _react2.default.createElement("path", {
+          d: "M 480.59183,75.709029 442.06274,38.831006 c -5.28301,-5.060423 -11.70817,-7.591583 -19.26056,-7.591583 -7.55937,0 -13.98453,2.53116 -19.26753,7.591583 L 217.6825,216.98773 134.38968,136.99258 c -5.28896,-5.06231 -11.71015,-7.59062 -19.26256,-7.59062 -7.55736,0 -13.97854,2.52831 -19.267516,7.59062 l -38.529082,36.87898 c -5.28897,5.06136 -7.932461,11.20929 -7.932461,18.44186 0,7.22686 2.643491,13.38049 7.932461,18.4409 l 102.555358,98.15873 38.53207,36.87803 c 5.28598,5.06421 11.70916,7.59253 19.26455,7.59253 7.5524,0 13.97558,-2.53496 19.26454,-7.59253 l 38.53107,-36.87803 205.11372,-196.32314 c 5.284,-5.06232 7.93246,-11.20929 7.93246,-18.441873 0.005,-7.228765 -2.64846,-13.376685 -7.93246,-18.439008 z" })
+      );
+    }
+  }]);
 
-	return CheckedIcon;
+  return CheckedIcon;
 }(_react2.default.Component);
 
 CheckedIcon.defaultProps = {};
 
 CheckedIcon.propTypes = {
-	title: _propTypes2.default.string
+  title: _propTypes2.default.string
 };
 
 exports.default = CheckedIcon;
@@ -2533,7 +2666,7 @@ exports.default = CheckedIcon;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -2551,26 +2684,27 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Search = function (_React$Component) {
-	_inherits(Search, _React$Component);
+  _inherits(Search, _React$Component);
 
-	function Search() {
-		_classCallCheck(this, Search);
+  function Search() {
+    _classCallCheck(this, Search);
 
-		return _possibleConstructorReturn(this, (Search.__proto__ || Object.getPrototypeOf(Search)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (Search.__proto__ || Object.getPrototypeOf(Search)).apply(this, arguments));
+  }
 
-	_createClass(Search, [{
-		key: "render",
-		value: function render() {
-			return _react2.default.createElement(
-				"svg",
-				{ className: "search-icon", viewBox: "0 0 250.313 250.313", width: "10" },
-				_react2.default.createElement("path", { d: "M244.186,214.604l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76 c10.7-16.231,16.945-35.66,16.945-56.554C205.822,46.075,159.747,0,102.911,0S0,46.075,0,102.911 c0,56.835,46.074,102.911,102.91,102.911c20.895,0,40.323-6.245,56.554-16.945c0.269,0.301,0.47,0.64,0.759,0.929l54.38,54.38 c8.169,8.168,21.413,8.168,29.583,0C252.354,236.017,252.354,222.773,244.186,214.604z M102.911,170.146 c-37.134,0-67.236-30.102-67.236-67.235c0-37.134,30.103-67.236,67.236-67.236c37.132,0,67.235,30.103,67.235,67.236 C170.146,140.044,140.043,170.146,102.911,170.146z" })
-			);
-		}
-	}]);
+  _createClass(Search, [{
+    key: "render",
+    value: function render() {
+      return _react2.default.createElement(
+        "svg",
+        { className: "search-icon", viewBox: "0 0 250.313 250.313", width: "10" },
+        _react2.default.createElement("path", {
+          d: "M244.186,214.604l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76 c10.7-16.231,16.945-35.66,16.945-56.554C205.822,46.075,159.747,0,102.911,0S0,46.075,0,102.911 c0,56.835,46.074,102.911,102.91,102.911c20.895,0,40.323-6.245,56.554-16.945c0.269,0.301,0.47,0.64,0.759,0.929l54.38,54.38 c8.169,8.168,21.413,8.168,29.583,0C252.354,236.017,252.354,222.773,244.186,214.604z M102.911,170.146 c-37.134,0-67.236-30.102-67.236-67.235c0-37.134,30.103-67.236,67.236-67.236c37.132,0,67.235,30.103,67.235,67.236 C170.146,140.044,140.043,170.146,102.911,170.146z" })
+      );
+    }
+  }]);
 
-	return Search;
+  return Search;
 }(_react2.default.Component);
 
 exports.default = Search;
@@ -2579,7 +2713,7 @@ exports.default = Search;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -2601,38 +2735,39 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var UncheckedIcon = function (_React$Component) {
-	_inherits(UncheckedIcon, _React$Component);
+  _inherits(UncheckedIcon, _React$Component);
 
-	function UncheckedIcon() {
-		_classCallCheck(this, UncheckedIcon);
+  function UncheckedIcon() {
+    _classCallCheck(this, UncheckedIcon);
 
-		return _possibleConstructorReturn(this, (UncheckedIcon.__proto__ || Object.getPrototypeOf(UncheckedIcon)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (UncheckedIcon.__proto__ || Object.getPrototypeOf(UncheckedIcon)).apply(this, arguments));
+  }
 
-	_createClass(UncheckedIcon, [{
-		key: "render",
-		value: function render() {
-			var title = this.props.title != null ? _react2.default.createElement(
-				"title",
-				null,
-				this.props.title
-			) : null;
+  _createClass(UncheckedIcon, [{
+    key: "render",
+    value: function render() {
+      var title = this.props.title != null ? _react2.default.createElement(
+        "title",
+        null,
+        this.props.title
+      ) : null;
 
-			return _react2.default.createElement(
-				"svg",
-				{ className: "checkbox-icon unchecked", viewBox: "0 0 401.998 401.998", width: "10" },
-				_react2.default.createElement("path", { d: "M377.87,24.126C361.786,8.042,342.417,0,319.769,0H82.227C59.579,0,40.211,8.042,24.125,24.126 C8.044,40.212,0.002,59.576,0.002,82.228v237.543c0,22.647,8.042,42.014,24.123,58.101c16.086,16.085,35.454,24.127,58.102,24.127 h237.542c22.648,0,42.011-8.042,58.102-24.127c16.085-16.087,24.126-35.453,24.126-58.101V82.228 C401.993,59.58,393.951,40.212,377.87,24.126z M365.448,319.771c0,12.559-4.47,23.314-13.415,32.264 c-8.945,8.945-19.698,13.411-32.265,13.411H82.227c-12.563,0-23.317-4.466-32.264-13.411c-8.945-8.949-13.418-19.705-13.418-32.264 V82.228c0-12.562,4.473-23.316,13.418-32.264c8.947-8.946,19.701-13.418,32.264-13.418h237.542 c12.566,0,23.319,4.473,32.265,13.418c8.945,8.947,13.415,19.701,13.415,32.264V319.771L365.448,319.771z" })
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "svg",
+        { className: "checkbox-icon unchecked", viewBox: "0 0 401.998 401.998", width: "10" },
+        _react2.default.createElement("path", {
+          d: "M377.87,24.126C361.786,8.042,342.417,0,319.769,0H82.227C59.579,0,40.211,8.042,24.125,24.126 C8.044,40.212,0.002,59.576,0.002,82.228v237.543c0,22.647,8.042,42.014,24.123,58.101c16.086,16.085,35.454,24.127,58.102,24.127 h237.542c22.648,0,42.011-8.042,58.102-24.127c16.085-16.087,24.126-35.453,24.126-58.101V82.228 C401.993,59.58,393.951,40.212,377.87,24.126z M365.448,319.771c0,12.559-4.47,23.314-13.415,32.264 c-8.945,8.945-19.698,13.411-32.265,13.411H82.227c-12.563,0-23.317-4.466-32.264-13.411c-8.945-8.949-13.418-19.705-13.418-32.264 V82.228c0-12.562,4.473-23.316,13.418-32.264c8.947-8.946,19.701-13.418,32.264-13.418h237.542 c12.566,0,23.319,4.473,32.265,13.418c8.945,8.947,13.415,19.701,13.415,32.264V319.771L365.448,319.771z" })
+      );
+    }
+  }]);
 
-	return UncheckedIcon;
+  return UncheckedIcon;
 }(_react2.default.Component);
 
 UncheckedIcon.defaultProps = {};
 
 UncheckedIcon.propTypes = {
-	title: _propTypes2.default.string
+  title: _propTypes2.default.string
 };
 
 exports.default = UncheckedIcon;
@@ -2641,7 +2776,7 @@ exports.default = UncheckedIcon;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -2675,188 +2810,200 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var ListFacet = function (_React$Component) {
-	_inherits(ListFacet, _React$Component);
+  _inherits(ListFacet, _React$Component);
 
-	function ListFacet(props) {
-		_classCallCheck(this, ListFacet);
+  function ListFacet(props) {
+    _classCallCheck(this, ListFacet);
 
-		var _this = _possibleConstructorReturn(this, (ListFacet.__proto__ || Object.getPrototypeOf(ListFacet)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (ListFacet.__proto__ || Object.getPrototypeOf(ListFacet)).call(this, props));
 
-		_this.state = {
-			filter: "",
-			truncateFacetListsAt: props.truncateFacetListsAt
-		};
-		return _this;
-	}
+    _this.state = {
+      filter: "",
+      truncateFacetListsAt: props.truncateFacetListsAt
+    };
+    return _this;
+  }
 
-	_createClass(ListFacet, [{
-		key: "handleClick",
-		value: function handleClick(value) {
-			var foundIdx = this.props.value.indexOf(value);
-			if (foundIdx < 0) {
-				this.props.onChange(this.props.field, this.props.value.concat(value));
-			} else {
-				this.props.onChange(this.props.field, this.props.value.filter(function (v, i) {
-					return i !== foundIdx;
-				}));
-			}
-		}
-	}, {
-		key: "toggleExpand",
-		value: function toggleExpand() {
-			this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _this2 = this;
+  _createClass(ListFacet, [{
+    key: "handleClick",
+    value: function handleClick(value) {
+      var foundIdx = this.props.value.indexOf(value);
+      if (foundIdx < 0) {
+        this.props.onChange(this.props.field, this.props.value.concat(value));
+      } else {
+        this.props.onChange(this.props.field, this.props.value.filter(function (v, i) {
+          return i !== foundIdx;
+        }));
+      }
+    }
+  }, {
+    key: "toggleExpand",
+    value: function toggleExpand() {
+      this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
 
-			var _props = this.props,
-			    query = _props.query,
-			    label = _props.label,
-			    facets = _props.facets,
-			    field = _props.field,
-			    value = _props.value,
-			    bootstrapCss = _props.bootstrapCss,
-			    facetSort = _props.facetSort,
-			    collapse = _props.collapse;
-			var truncateFacetListsAt = this.state.truncateFacetListsAt;
+      var _props = this.props,
+          query = _props.query,
+          label = _props.label,
+          facets = _props.facets,
+          field = _props.field,
+          value = _props.value,
+          bootstrapCss = _props.bootstrapCss,
+          facetSort = _props.facetSort,
+          collapse = _props.collapse;
+      var truncateFacetListsAt = this.state.truncateFacetListsAt;
 
 
-			var facetCounts = facets.filter(function (facet, i) {
-				return i % 2 === 1;
-			});
-			var facetValues = facets.filter(function (facet, i) {
-				return i % 2 === 0;
-			});
+      var facetCounts = facets.filter(function (facet, i) {
+        return i % 2 === 1;
+      });
+      var facetValues = facets.filter(function (facet, i) {
+        return i % 2 === 0;
+      });
 
-			var facetSortValue = facetSort ? facetSort : query.facetSort ? query.facetSort : query.facetLimit && query.facetLimit > -1 ? "count" : "index";
+      var facetSortValue = facetSort ? facetSort : query.facetSort ? query.facetSort : query.facetLimit && query.facetLimit > -1 ? "count" : "index";
 
-			var expanded = !(collapse || false);
+      var expanded = !(collapse || false);
 
-			var showMoreLink = truncateFacetListsAt > -1 && truncateFacetListsAt < facetValues.length ? _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), onClick: function onClick() {
-						return _this2.setState({ truncateFacetListsAt: -1 });
-					} },
-				"Show all (",
-				facetValues.length,
-				")"
-			) : null;
+      var showMoreLink = truncateFacetListsAt > -1 && truncateFacetListsAt < facetValues.length ? _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), onClick: function onClick() {
+            return _this2.setState({ truncateFacetListsAt: -1 });
+          } },
+        "Show all (",
+        facetValues.length,
+        ")"
+      ) : null;
 
-			return _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)("list-facet", { "list-group-item": bootstrapCss }), id: "solr-list-facet-" + field },
-				_react2.default.createElement(
-					"header",
-					{ onClick: this.toggleExpand.bind(this) },
-					_react2.default.createElement(
-						"h5",
-						null,
-						bootstrapCss ? _react2.default.createElement(
-							"span",
-							null,
-							_react2.default.createElement("span", { className: (0, _classnames2.default)("glyphicon", {
-									"glyphicon-collapse-down": expanded,
-									"glyphicon-collapse-up": !expanded
-								}) }),
-							" "
-						) : null,
-						label
-					)
-				),
-				expanded ? _react2.default.createElement(
-					"div",
-					null,
-					_react2.default.createElement(
-						"ul",
-						{ className: (0, _classnames2.default)({ "list-group": bootstrapCss }) },
-						facetValues.filter(function (facetValue, i) {
-							return truncateFacetListsAt < 0 || i < truncateFacetListsAt;
-						}).map(function (facetValue, i) {
-							return _this2.state.filter.length === 0 || facetValue.toLowerCase().indexOf(_this2.state.filter.toLowerCase()) > -1 ? _react2.default.createElement(
-								"li",
-								{ className: (0, _classnames2.default)("facet-item-type-" + field, { "list-group-item": bootstrapCss }), key: facetValue + "_" + facetCounts[i], onClick: function onClick() {
-										return _this2.handleClick(facetValue);
-									} },
-								value.indexOf(facetValue) > -1 ? _react2.default.createElement(_checked2.default, null) : _react2.default.createElement(_unchecked2.default, null),
-								" ",
-								facetValue,
-								_react2.default.createElement(
-									"span",
-									{ className: "facet-item-amount" },
-									facetCounts[i]
-								)
-							) : null;
-						}),
-						showMoreLink
-					),
-					facetValues.length > 4 ? _react2.default.createElement(
-						"div",
-						null,
-						_react2.default.createElement("input", { onChange: function onChange(ev) {
-								return _this2.setState({ filter: ev.target.value });
-							}, placeholder: "Filter... ", type: "text", value: this.state.filter }),
-						"\xA0",
-						_react2.default.createElement(
-							"span",
-							{ className: (0, _classnames2.default)({ "btn-group": bootstrapCss }) },
-							_react2.default.createElement(
-								"button",
-								{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss, active: facetSortValue === "index" }),
-									onClick: function onClick() {
-										return _this2.props.onFacetSortChange(field, "index");
-									} },
-								"a-z"
-							),
-							_react2.default.createElement(
-								"button",
-								{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss, active: facetSortValue === "count" }),
-									onClick: function onClick() {
-										return _this2.props.onFacetSortChange(field, "count");
-									} },
-								"0-9"
-							)
-						),
-						_react2.default.createElement(
-							"span",
-							{ className: (0, _classnames2.default)({ "btn-group": bootstrapCss, "pull-right": bootstrapCss }) },
-							_react2.default.createElement(
-								"button",
-								{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss }),
-									onClick: function onClick() {
-										return _this2.props.onChange(field, []);
-									} },
-								"clear"
-							)
-						)
-					) : null
-				) : null
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)("list-facet", { "list-group-item": bootstrapCss }), id: "solr-list-facet-" + field },
+        _react2.default.createElement(
+          "header",
+          { onClick: this.toggleExpand.bind(this) },
+          _react2.default.createElement(
+            "h5",
+            null,
+            bootstrapCss ? _react2.default.createElement(
+              "span",
+              null,
+              _react2.default.createElement("span", { className: (0, _classnames2.default)("glyphicon", {
+                  "glyphicon-collapse-down": expanded,
+                  "glyphicon-collapse-up": !expanded
+                }) }),
+              " "
+            ) : null,
+            label
+          )
+        ),
+        expanded ? _react2.default.createElement(
+          "div",
+          null,
+          _react2.default.createElement(
+            "ul",
+            { className: (0, _classnames2.default)({ "list-group": bootstrapCss }) },
+            facetValues.filter(function (facetValue, i) {
+              return truncateFacetListsAt < 0 || i < truncateFacetListsAt;
+            }).map(function (facetValue, i) {
+              return _this2.state.filter.length === 0 || facetValue.toLowerCase().indexOf(_this2.state.filter.toLowerCase()) > -1 ? _react2.default.createElement(
+                "li",
+                { className: (0, _classnames2.default)("facet-item-type-" + field, { "list-group-item": bootstrapCss }),
+                  key: facetValue + "_" + facetCounts[i], onClick: function onClick() {
+                    return _this2.handleClick(facetValue);
+                  } },
+                value.indexOf(facetValue) > -1 ? _react2.default.createElement(_checked2.default, null) : _react2.default.createElement(_unchecked2.default, null),
+                " ",
+                facetValue,
+                _react2.default.createElement(
+                  "span",
+                  { className: "facet-item-amount" },
+                  facetCounts[i]
+                )
+              ) : null;
+            }),
+            showMoreLink
+          ),
+          facetValues.length > 4 ? _react2.default.createElement(
+            "div",
+            null,
+            _react2.default.createElement("input", { onChange: function onChange(ev) {
+                return _this2.setState({ filter: ev.target.value });
+              }, placeholder: "Filter... ", type: "text",
+              value: this.state.filter }),
+            "\xA0",
+            _react2.default.createElement(
+              "span",
+              { className: (0, _classnames2.default)({ "btn-group": bootstrapCss }) },
+              _react2.default.createElement(
+                "button",
+                { className: (0, _classnames2.default)({
+                    "btn": bootstrapCss,
+                    "btn-default": bootstrapCss,
+                    "btn-xs": bootstrapCss,
+                    active: facetSortValue === "index"
+                  }),
+                  onClick: function onClick() {
+                    return _this2.props.onFacetSortChange(field, "index");
+                  } },
+                "a-z"
+              ),
+              _react2.default.createElement(
+                "button",
+                { className: (0, _classnames2.default)({
+                    "btn": bootstrapCss,
+                    "btn-default": bootstrapCss,
+                    "btn-xs": bootstrapCss,
+                    active: facetSortValue === "count"
+                  }),
+                  onClick: function onClick() {
+                    return _this2.props.onFacetSortChange(field, "count");
+                  } },
+                "0-9"
+              )
+            ),
+            _react2.default.createElement(
+              "span",
+              { className: (0, _classnames2.default)({ "btn-group": bootstrapCss, "pull-right": bootstrapCss }) },
+              _react2.default.createElement(
+                "button",
+                { className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss }),
+                  onClick: function onClick() {
+                    return _this2.props.onChange(field, []);
+                  } },
+                "clear"
+              )
+            )
+          ) : null
+        ) : null
+      );
+    }
+  }]);
 
-	return ListFacet;
+  return ListFacet;
 }(_react2.default.Component);
 
 ListFacet.defaultProps = {
-	value: []
+  value: []
 };
 
 ListFacet.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	children: _propTypes2.default.array,
-	collapse: _propTypes2.default.bool,
-	facetSort: _propTypes2.default.string,
-	facets: _propTypes2.default.array.isRequired,
-	field: _propTypes2.default.string.isRequired,
-	label: _propTypes2.default.string,
-	onChange: _propTypes2.default.func,
-	onFacetSortChange: _propTypes2.default.func,
-	onSetCollapse: _propTypes2.default.func,
-	query: _propTypes2.default.object,
-	truncateFacetListsAt: _propTypes2.default.number,
-	value: _propTypes2.default.array
+  bootstrapCss: _propTypes2.default.bool,
+  children: _propTypes2.default.array,
+  collapse: _propTypes2.default.bool,
+  facetSort: _propTypes2.default.string,
+  facets: _propTypes2.default.array.isRequired,
+  field: _propTypes2.default.string.isRequired,
+  label: _propTypes2.default.string,
+  onChange: _propTypes2.default.func,
+  onFacetSortChange: _propTypes2.default.func,
+  onSetCollapse: _propTypes2.default.func,
+  query: _propTypes2.default.object,
+  truncateFacetListsAt: _propTypes2.default.number,
+  value: _propTypes2.default.array
 };
 
 exports.default = ListFacet;
@@ -2865,7 +3012,7 @@ exports.default = ListFacet;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -2895,161 +3042,163 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var RangeFacet = function (_React$Component) {
-	_inherits(RangeFacet, _React$Component);
+  _inherits(RangeFacet, _React$Component);
 
-	function RangeFacet(props) {
-		_classCallCheck(this, RangeFacet);
+  function RangeFacet(props) {
+    _classCallCheck(this, RangeFacet);
 
-		var _this = _possibleConstructorReturn(this, (RangeFacet.__proto__ || Object.getPrototypeOf(RangeFacet)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (RangeFacet.__proto__ || Object.getPrototypeOf(RangeFacet)).call(this, props));
 
-		_this.state = {
-			value: props.value
-		};
-		return _this;
-	}
+    _this.state = {
+      value: props.value
+    };
+    return _this;
+  }
 
-	_createClass(RangeFacet, [{
-		key: "componentWillReceiveProps",
-		value: function componentWillReceiveProps(nextProps) {
-			this.setState({ value: nextProps.value });
-		}
-	}, {
-		key: "facetsToRange",
-		value: function facetsToRange() {
-			var facets = this.props.facets;
-
-
-			return facets.filter(function (facet, i) {
-				return i % 2 === 0;
-			}).map(function (v) {
-				return parseInt(v);
-			}).sort(function (a, b) {
-				return a > b ? 1 : -1;
-			}).filter(function (a, i, me) {
-				return i === 0 || i === me.length - 1;
-			});
-		}
-	}, {
-		key: "onRangeChange",
-		value: function onRangeChange(range) {
-			var bounds = this.facetsToRange();
-			var lowerBound = bounds[0];
-			var upperBound = bounds[1];
-			var realRange = upperBound - lowerBound;
-
-			var newState = {
-				value: [Math.floor(range.lowerLimit * realRange) + lowerBound, Math.ceil(range.upperLimit * realRange) + lowerBound]
-			};
-
-			if (range.refresh) {
-				this.props.onChange(this.props.field, newState.value);
-			} else {
-				this.setState(newState);
-			}
-		}
-	}, {
-		key: "getPercentage",
-		value: function getPercentage(range, value) {
-			var lowerBound = range[0];
-			var upperBound = range[1];
-			var realRange = upperBound - lowerBound;
-
-			var atRange = value - lowerBound;
-			return atRange / realRange;
-		}
-	}, {
-		key: "toggleExpand",
-		value: function toggleExpand(ev) {
-			if (ev.target.className.indexOf("clear-button") < 0) {
-				this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
-			}
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _this2 = this;
-
-			var _props = this.props,
-			    label = _props.label,
-			    field = _props.field,
-			    bootstrapCss = _props.bootstrapCss,
-			    collapse = _props.collapse;
-			var value = this.state.value;
+  _createClass(RangeFacet, [{
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(nextProps) {
+      this.setState({ value: nextProps.value });
+    }
+  }, {
+    key: "facetsToRange",
+    value: function facetsToRange() {
+      var facets = this.props.facets;
 
 
-			var range = this.facetsToRange();
+      return facets.filter(function (facet, i) {
+        return i % 2 === 0;
+      }).map(function (v) {
+        return parseInt(v);
+      }).sort(function (a, b) {
+        return a > b ? 1 : -1;
+      }).filter(function (a, i, me) {
+        return i === 0 || i === me.length - 1;
+      });
+    }
+  }, {
+    key: "onRangeChange",
+    value: function onRangeChange(range) {
+      var bounds = this.facetsToRange();
+      var lowerBound = bounds[0];
+      var upperBound = bounds[1];
+      var realRange = upperBound - lowerBound;
 
-			var filterRange = value.length > 0 ? value : range;
+      var newState = {
+        value: [Math.floor(range.lowerLimit * realRange) + lowerBound, Math.ceil(range.upperLimit * realRange) + lowerBound]
+      };
 
-			return _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)("range-facet", { "list-group-item": bootstrapCss }), id: "solr-range-facet-" + field },
-				_react2.default.createElement(
-					"header",
-					{ onClick: this.toggleExpand.bind(this) },
-					_react2.default.createElement(
-						"button",
-						{ style: { display: this.state.expanded ? "block" : "none" },
-							className: (0, _classnames2.default)("clear-button", {
-								"btn": bootstrapCss,
-								"btn-default": bootstrapCss,
-								"btn-xs": bootstrapCss,
-								"pull-right": bootstrapCss }),
-							onClick: function onClick() {
-								return _this2.props.onChange(field, []);
-							} },
-						"clear"
-					),
-					_react2.default.createElement(
-						"h5",
-						null,
-						bootstrapCss ? _react2.default.createElement(
-							"span",
-							null,
-							_react2.default.createElement("span", { className: (0, _classnames2.default)("glyphicon", {
-									"glyphicon-collapse-down": !collapse,
-									"glyphicon-collapse-up": collapse
-								}) }),
-							" "
-						) : null,
-						label
-					)
-				),
-				_react2.default.createElement(
-					"div",
-					{ style: { display: collapse ? "none" : "block" } },
-					_react2.default.createElement(_rangeSlider2.default, { lowerLimit: this.getPercentage(range, filterRange[0]), onChange: this.onRangeChange.bind(this), upperLimit: this.getPercentage(range, filterRange[1]) }),
-					_react2.default.createElement(
-						"label",
-						null,
-						filterRange[0]
-					),
-					_react2.default.createElement(
-						"label",
-						{ className: (0, _classnames2.default)({ "pull-right": bootstrapCss }) },
-						filterRange[1]
-					)
-				)
-			);
-		}
-	}]);
+      if (range.refresh) {
+        this.props.onChange(this.props.field, newState.value);
+      } else {
+        this.setState(newState);
+      }
+    }
+  }, {
+    key: "getPercentage",
+    value: function getPercentage(range, value) {
+      var lowerBound = range[0];
+      var upperBound = range[1];
+      var realRange = upperBound - lowerBound;
 
-	return RangeFacet;
+      var atRange = value - lowerBound;
+      return atRange / realRange;
+    }
+  }, {
+    key: "toggleExpand",
+    value: function toggleExpand(ev) {
+      if (ev.target.className.indexOf("clear-button") < 0) {
+        this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
+      }
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      var _props = this.props,
+          label = _props.label,
+          field = _props.field,
+          bootstrapCss = _props.bootstrapCss,
+          collapse = _props.collapse;
+      var value = this.state.value;
+
+
+      var range = this.facetsToRange();
+
+      var filterRange = value.length > 0 ? value : range;
+
+      return _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)("range-facet", { "list-group-item": bootstrapCss }), id: "solr-range-facet-" + field },
+        _react2.default.createElement(
+          "header",
+          { onClick: this.toggleExpand.bind(this) },
+          _react2.default.createElement(
+            "button",
+            { style: { display: this.state.expanded ? "block" : "none" },
+              className: (0, _classnames2.default)("clear-button", {
+                "btn": bootstrapCss,
+                "btn-default": bootstrapCss,
+                "btn-xs": bootstrapCss,
+                "pull-right": bootstrapCss
+              }),
+              onClick: function onClick() {
+                return _this2.props.onChange(field, []);
+              } },
+            "clear"
+          ),
+          _react2.default.createElement(
+            "h5",
+            null,
+            bootstrapCss ? _react2.default.createElement(
+              "span",
+              null,
+              _react2.default.createElement("span", { className: (0, _classnames2.default)("glyphicon", {
+                  "glyphicon-collapse-down": !collapse,
+                  "glyphicon-collapse-up": collapse
+                }) }),
+              " "
+            ) : null,
+            label
+          )
+        ),
+        _react2.default.createElement(
+          "div",
+          { style: { display: collapse ? "none" : "block" } },
+          _react2.default.createElement(_rangeSlider2.default, { lowerLimit: this.getPercentage(range, filterRange[0]), onChange: this.onRangeChange.bind(this),
+            upperLimit: this.getPercentage(range, filterRange[1]) }),
+          _react2.default.createElement(
+            "label",
+            null,
+            filterRange[0]
+          ),
+          _react2.default.createElement(
+            "label",
+            { className: (0, _classnames2.default)({ "pull-right": bootstrapCss }) },
+            filterRange[1]
+          )
+        )
+      );
+    }
+  }]);
+
+  return RangeFacet;
 }(_react2.default.Component);
 
 RangeFacet.defaultProps = {
-	value: []
+  value: []
 };
 
 RangeFacet.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	collapse: _propTypes2.default.bool,
-	facets: _propTypes2.default.array.isRequired,
-	field: _propTypes2.default.string.isRequired,
-	label: _propTypes2.default.string,
-	onChange: _propTypes2.default.func,
-	onSetCollapse: _propTypes2.default.func,
-	value: _propTypes2.default.array
+  bootstrapCss: _propTypes2.default.bool,
+  collapse: _propTypes2.default.bool,
+  facets: _propTypes2.default.array.isRequired,
+  field: _propTypes2.default.string.isRequired,
+  label: _propTypes2.default.string,
+  onChange: _propTypes2.default.func,
+  onSetCollapse: _propTypes2.default.func,
+  value: _propTypes2.default.array
 };
 
 exports.default = RangeFacet;
@@ -3058,7 +3207,7 @@ exports.default = RangeFacet;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -3089,195 +3238,195 @@ var MOUSE_DOWN = 0;
 var MOUSE_UP = 1;
 
 var styles = {
-	slider: {
-		"MozUserSelect": "none",
-		"WebkitUserSelect": "none",
-		"MsUserSelect": "none",
-		"UserSelect": "none",
-		"WebkitUserDrag": "none",
-		"userDrag": "none",
-		"cursor": "pointer",
-		width: "100%",
-		stroke: "#f1ebe6",
-		fill: "#f1ebe6"
-	}
+  slider: {
+    "MozUserSelect": "none",
+    "WebkitUserSelect": "none",
+    "MsUserSelect": "none",
+    "UserSelect": "none",
+    "WebkitUserDrag": "none",
+    "userDrag": "none",
+    "cursor": "pointer",
+    width: "100%",
+    stroke: "#f1ebe6",
+    fill: "#f1ebe6"
+  }
 };
 
 var RangeSlider = function (_React$Component) {
-	_inherits(RangeSlider, _React$Component);
+  _inherits(RangeSlider, _React$Component);
 
-	function RangeSlider(props) {
-		_classCallCheck(this, RangeSlider);
+  function RangeSlider(props) {
+    _classCallCheck(this, RangeSlider);
 
-		var _this = _possibleConstructorReturn(this, (RangeSlider.__proto__ || Object.getPrototypeOf(RangeSlider)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (RangeSlider.__proto__ || Object.getPrototypeOf(RangeSlider)).call(this, props));
 
-		_this.mouseState = MOUSE_UP;
-		_this.mouseUpListener = _this.onMouseUp.bind(_this);
-		_this.mouseMoveListener = _this.onMouseMove.bind(_this);
-		_this.touchMoveListener = _this.onTouchMove.bind(_this);
+    _this.mouseState = MOUSE_UP;
+    _this.mouseUpListener = _this.onMouseUp.bind(_this);
+    _this.mouseMoveListener = _this.onMouseMove.bind(_this);
+    _this.touchMoveListener = _this.onTouchMove.bind(_this);
 
-		_this.state = _extends({}, _this.propsToState(_this.props), { hoverState: null });
-		return _this;
-	}
+    _this.state = _extends({}, _this.propsToState(_this.props), { hoverState: null });
+    return _this;
+  }
 
-	_createClass(RangeSlider, [{
-		key: "componentDidMount",
-		value: function componentDidMount() {
-			window.addEventListener("mouseup", this.mouseUpListener);
-			window.addEventListener("mousemove", this.mouseMoveListener);
-			window.addEventListener("touchend", this.mouseUpListener);
-			window.addEventListener("touchmove", this.touchMoveListener);
-		}
-	}, {
-		key: "componentWillReceiveProps",
-		value: function componentWillReceiveProps(nextProps) {
-			this.setState(this.propsToState(nextProps));
-		}
-	}, {
-		key: "componentWillUnmount",
-		value: function componentWillUnmount() {
-			window.removeEventListener("mouseup", this.mouseUpListener);
-			window.removeEventListener("mousemove", this.mouseMoveListener);
-			window.removeEventListener("touchend", this.mouseUpListener);
-			window.removeEventListener("touchmove", this.touchMoveListener);
-		}
-	}, {
-		key: "propsToState",
-		value: function propsToState(props) {
-			var lowerLimit = props.lowerLimit || 0;
-			var upperLimit = props.upperLimit || 1;
-			return {
-				lowerLimit: lowerLimit,
-				upperLimit: upperLimit
-			};
-		}
-	}, {
-		key: "getPositionForLimit",
-		value: function getPositionForLimit(pageX) {
-			var rect = _reactDom2.default.findDOMNode(this).getBoundingClientRect();
-			if (rect.width > 0) {
-				var percentage = (pageX - rect.left) / rect.width;
-				if (percentage > 1) {
-					percentage = 1;
-				} else if (percentage < 0) {
-					percentage = 0;
-				}
-				var center = (this.state.upperLimit + this.state.lowerLimit) / 2;
+  _createClass(RangeSlider, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      window.addEventListener("mouseup", this.mouseUpListener);
+      window.addEventListener("mousemove", this.mouseMoveListener);
+      window.addEventListener("touchend", this.mouseUpListener);
+      window.addEventListener("touchmove", this.touchMoveListener);
+    }
+  }, {
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(nextProps) {
+      this.setState(this.propsToState(nextProps));
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      window.removeEventListener("mouseup", this.mouseUpListener);
+      window.removeEventListener("mousemove", this.mouseMoveListener);
+      window.removeEventListener("touchend", this.mouseUpListener);
+      window.removeEventListener("touchmove", this.touchMoveListener);
+    }
+  }, {
+    key: "propsToState",
+    value: function propsToState(props) {
+      var lowerLimit = props.lowerLimit || 0;
+      var upperLimit = props.upperLimit || 1;
+      return {
+        lowerLimit: lowerLimit,
+        upperLimit: upperLimit
+      };
+    }
+  }, {
+    key: "getPositionForLimit",
+    value: function getPositionForLimit(pageX) {
+      var rect = _reactDom2.default.findDOMNode(this).getBoundingClientRect();
+      if (rect.width > 0) {
+        var percentage = (pageX - rect.left) / rect.width;
+        if (percentage > 1) {
+          percentage = 1;
+        } else if (percentage < 0) {
+          percentage = 0;
+        }
+        var center = (this.state.upperLimit + this.state.lowerLimit) / 2;
 
-				if (this.state.hoverState === "bar") {
-					var lowerLimit = percentage + this.state.lowerLimit - center;
-					var upperLimit = percentage - (center - this.state.upperLimit);
-					if (upperLimit >= 1) {
-						upperLimit = 1;
-					}
-					if (lowerLimit <= 0) {
-						lowerLimit = 0;
-					}
-					return { lowerLimit: lowerLimit, upperLimit: upperLimit };
-				} else if (this.state.hoverState === "lowerLimit") {
-					if (percentage >= this.state.upperLimit) {
-						percentage = this.state.upperLimit;
-					}
-					return { lowerLimit: percentage };
-				} else if (this.state.hoverState === "upperLimit") {
-					if (percentage <= this.state.lowerLimit) {
-						percentage = this.state.lowerLimit;
-					}
-					return { upperLimit: percentage };
-				}
-			}
-			return null;
-		}
-	}, {
-		key: "setRange",
-		value: function setRange(pageX) {
-			var posForLim = this.getPositionForLimit(pageX);
-			if (posForLim !== null) {
-				this.setState(posForLim);
-				this.props.onChange(_extends({}, this.state, { refresh: false }));
-			}
-		}
-	}, {
-		key: "onMouseDown",
-		value: function onMouseDown(target, ev) {
-			this.mouseState = MOUSE_DOWN;
-			this.setState({ hoverState: target });
-			return ev.preventDefault();
-		}
-	}, {
-		key: "onMouseMove",
-		value: function onMouseMove(ev) {
-			if (this.mouseState === MOUSE_DOWN) {
-				this.setRange(ev.pageX);
-				return ev.preventDefault();
-			}
-		}
-	}, {
-		key: "onTouchMove",
-		value: function onTouchMove(ev) {
-			if (this.mouseState === MOUSE_DOWN) {
-				this.setRange(ev.touches[0].pageX);
-				return ev.preventDefault();
-			}
-		}
-	}, {
-		key: "onMouseUp",
-		value: function onMouseUp() {
-			if (this.mouseState === MOUSE_DOWN) {
-				this.props.onChange(_extends({}, this.state, { refresh: true }));
-			}
-			this.setState({ hoverState: null });
-			this.mouseState = MOUSE_UP;
-		}
-	}, {
-		key: "getRangePath",
-		value: function getRangePath() {
-			return "M" + (8 + Math.floor(this.state.lowerLimit * 400)) + " 13 L " + (Math.ceil(this.state.upperLimit * 400) - 8) + " 13 Z";
-		}
-	}, {
-		key: "getRangeCircle",
-		value: function getRangeCircle(key) {
-			var percentage = this.state[key];
-			return _react2.default.createElement("circle", {
-				className: this.state.hoverState === key ? "hovering" : "",
-				cx: percentage * 400, cy: "13",
-				onMouseDown: this.onMouseDown.bind(this, key),
-				onTouchStart: this.onMouseDown.bind(this, key),
-				r: "13" });
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var keys = this.state.hoverState === "lowerLimit" ? ["upperLimit", "lowerLimit"] : ["lowerLimit", "upperLimit"];
-			return _react2.default.createElement(
-				"svg",
-				{ className: "facet-range-slider", viewBox: "0 0 400 26" },
-				_react2.default.createElement("path", { d: "M0 0 L 0 26 Z", fill: "transparent" }),
-				_react2.default.createElement("path", { d: "M400 0 L 400 26 Z", fill: "transparent" }),
-				_react2.default.createElement("path", { d: "M0 13 L 400 13 Z", fill: "transparent" }),
-				_react2.default.createElement(
-					"g",
-					{ className: "range-line" },
-					_react2.default.createElement("path", {
-						className: this.state.hoverState === "bar" ? "hovering" : "",
-						d: this.getRangePath(),
-						onMouseDown: this.onMouseDown.bind(this, "bar"),
-						onTouchStart: this.onMouseDown.bind(this, "bar")
-					}),
-					this.getRangeCircle(keys[0]),
-					this.getRangeCircle(keys[1])
-				)
-			);
-		}
-	}]);
+        if (this.state.hoverState === "bar") {
+          var lowerLimit = percentage + this.state.lowerLimit - center;
+          var upperLimit = percentage - (center - this.state.upperLimit);
+          if (upperLimit >= 1) {
+            upperLimit = 1;
+          }
+          if (lowerLimit <= 0) {
+            lowerLimit = 0;
+          }
+          return { lowerLimit: lowerLimit, upperLimit: upperLimit };
+        } else if (this.state.hoverState === "lowerLimit") {
+          if (percentage >= this.state.upperLimit) {
+            percentage = this.state.upperLimit;
+          }
+          return { lowerLimit: percentage };
+        } else if (this.state.hoverState === "upperLimit") {
+          if (percentage <= this.state.lowerLimit) {
+            percentage = this.state.lowerLimit;
+          }
+          return { upperLimit: percentage };
+        }
+      }
+      return null;
+    }
+  }, {
+    key: "setRange",
+    value: function setRange(pageX) {
+      var posForLim = this.getPositionForLimit(pageX);
+      if (posForLim !== null) {
+        this.setState(posForLim);
+        this.props.onChange(_extends({}, this.state, { refresh: false }));
+      }
+    }
+  }, {
+    key: "onMouseDown",
+    value: function onMouseDown(target, ev) {
+      this.mouseState = MOUSE_DOWN;
+      this.setState({ hoverState: target });
+      return ev.preventDefault();
+    }
+  }, {
+    key: "onMouseMove",
+    value: function onMouseMove(ev) {
+      if (this.mouseState === MOUSE_DOWN) {
+        this.setRange(ev.pageX);
+        return ev.preventDefault();
+      }
+    }
+  }, {
+    key: "onTouchMove",
+    value: function onTouchMove(ev) {
+      if (this.mouseState === MOUSE_DOWN) {
+        this.setRange(ev.touches[0].pageX);
+        return ev.preventDefault();
+      }
+    }
+  }, {
+    key: "onMouseUp",
+    value: function onMouseUp() {
+      if (this.mouseState === MOUSE_DOWN) {
+        this.props.onChange(_extends({}, this.state, { refresh: true }));
+      }
+      this.setState({ hoverState: null });
+      this.mouseState = MOUSE_UP;
+    }
+  }, {
+    key: "getRangePath",
+    value: function getRangePath() {
+      return "M" + (8 + Math.floor(this.state.lowerLimit * 400)) + " 13 L " + (Math.ceil(this.state.upperLimit * 400) - 8) + " 13 Z";
+    }
+  }, {
+    key: "getRangeCircle",
+    value: function getRangeCircle(key) {
+      var percentage = this.state[key];
+      return _react2.default.createElement("circle", {
+        className: this.state.hoverState === key ? "hovering" : "",
+        cx: percentage * 400, cy: "13",
+        onMouseDown: this.onMouseDown.bind(this, key),
+        onTouchStart: this.onMouseDown.bind(this, key),
+        r: "13" });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var keys = this.state.hoverState === "lowerLimit" ? ["upperLimit", "lowerLimit"] : ["lowerLimit", "upperLimit"];
+      return _react2.default.createElement(
+        "svg",
+        { className: "facet-range-slider", viewBox: "0 0 400 26" },
+        _react2.default.createElement("path", { d: "M0 0 L 0 26 Z", fill: "transparent" }),
+        _react2.default.createElement("path", { d: "M400 0 L 400 26 Z", fill: "transparent" }),
+        _react2.default.createElement("path", { d: "M0 13 L 400 13 Z", fill: "transparent" }),
+        _react2.default.createElement(
+          "g",
+          { className: "range-line" },
+          _react2.default.createElement("path", {
+            className: this.state.hoverState === "bar" ? "hovering" : "",
+            d: this.getRangePath(),
+            onMouseDown: this.onMouseDown.bind(this, "bar"),
+            onTouchStart: this.onMouseDown.bind(this, "bar")
+          }),
+          this.getRangeCircle(keys[0]),
+          this.getRangeCircle(keys[1])
+        )
+      );
+    }
+  }]);
 
-	return RangeSlider;
+  return RangeSlider;
 }(_react2.default.Component);
 
 RangeSlider.propTypes = {
-	lowerLimit: _propTypes2.default.number,
-	onChange: _propTypes2.default.func.isRequired,
-	upperLimit: _propTypes2.default.number
+  lowerLimit: _propTypes2.default.number,
+  onChange: _propTypes2.default.func.isRequired,
+  upperLimit: _propTypes2.default.number
 };
 
 exports.default = RangeSlider;
@@ -3286,7 +3435,7 @@ exports.default = RangeSlider;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3312,37 +3461,37 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var ResultContainer = function (_React$Component) {
-	_inherits(ResultContainer, _React$Component);
+  _inherits(ResultContainer, _React$Component);
 
-	function ResultContainer() {
-		_classCallCheck(this, ResultContainer);
+  function ResultContainer() {
+    _classCallCheck(this, ResultContainer);
 
-		return _possibleConstructorReturn(this, (ResultContainer.__proto__ || Object.getPrototypeOf(ResultContainer)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (ResultContainer.__proto__ || Object.getPrototypeOf(ResultContainer)).apply(this, arguments));
+  }
 
-	_createClass(ResultContainer, [{
-		key: "render",
-		value: function render() {
-			var bootstrapCss = this.props.bootstrapCss;
+  _createClass(ResultContainer, [{
+    key: "render",
+    value: function render() {
+      var bootstrapCss = this.props.bootstrapCss;
 
-			return _react2.default.createElement(
-				"div",
-				{ className: (0, _classnames2.default)("solr-search-results", { "col-md-9": bootstrapCss }) },
-				_react2.default.createElement(
-					"div",
-					{ className: (0, _classnames2.default)({ "panel": bootstrapCss, "panel-default": bootstrapCss }) },
-					this.props.children
-				)
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "div",
+        { className: (0, _classnames2.default)("solr-search-results", { "col-md-9": bootstrapCss }) },
+        _react2.default.createElement(
+          "div",
+          { className: (0, _classnames2.default)({ "panel": bootstrapCss, "panel-default": bootstrapCss }) },
+          this.props.children
+        )
+      );
+    }
+  }]);
 
-	return ResultContainer;
+  return ResultContainer;
 }(_react2.default.Component);
 
 ResultContainer.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	children: _propTypes2.default.array
+  bootstrapCss: _propTypes2.default.bool,
+  children: _propTypes2.default.array
 };
 
 exports.default = ResultContainer;
@@ -3351,7 +3500,7 @@ exports.default = ResultContainer;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3373,40 +3522,40 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var resultCountLabels = {
-	pl: "Found % results",
-	sg: "Found % result",
-	none: "No results"
+  pl: "Found % results",
+  sg: "Found % result",
+  none: "No results"
 };
 
 var Result = function (_React$Component) {
-	_inherits(Result, _React$Component);
+  _inherits(Result, _React$Component);
 
-	function Result() {
-		_classCallCheck(this, Result);
+  function Result() {
+    _classCallCheck(this, Result);
 
-		return _possibleConstructorReturn(this, (Result.__proto__ || Object.getPrototypeOf(Result)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (Result.__proto__ || Object.getPrototypeOf(Result)).apply(this, arguments));
+  }
 
-	_createClass(Result, [{
-		key: "render",
-		value: function render() {
-			var numFound = this.props.numFound;
+  _createClass(Result, [{
+    key: "render",
+    value: function render() {
+      var numFound = this.props.numFound;
 
-			var resultLabel = numFound > 1 ? resultCountLabels.pl : numFound === 1 ? resultCountLabels.sg : resultCountLabels.none;
+      var resultLabel = numFound > 1 ? resultCountLabels.pl : numFound === 1 ? resultCountLabels.sg : resultCountLabels.none;
 
-			return _react2.default.createElement(
-				"label",
-				null,
-				resultLabel.replace("%", numFound)
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "label",
+        null,
+        resultLabel.replace("%", numFound)
+      );
+    }
+  }]);
 
-	return Result;
+  return Result;
 }(_react2.default.Component);
 
 Result.propTypes = {
-	numFound: _propTypes2.default.number.isRequired
+  numFound: _propTypes2.default.number.isRequired
 };
 
 exports.default = Result;
@@ -3415,18 +3564,23 @@ exports.default = Result;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 exports.default = function (props) {
-	var bootstrapCss = props.bootstrapCss,
-	    onClick = props.onClick;
+  var bootstrapCss = props.bootstrapCss,
+      onClick = props.onClick;
 
-	return _react2.default.createElement(
-		"button",
-		{ onClick: onClick, className: (0, _classnames2.default)({ btn: bootstrapCss, "btn-default": bootstrapCss, "pull-right": bootstrapCss, "btn-xs": bootstrapCss }) },
-		"Export excel"
-	);
+  return _react2.default.createElement(
+    "button",
+    { onClick: onClick, className: (0, _classnames2.default)({
+        btn: bootstrapCss,
+        "btn-default": bootstrapCss,
+        "pull-right": bootstrapCss,
+        "btn-xs": bootstrapCss
+      }) },
+    "Export excel"
+  );
 };
 
 var _react = _dereq_("react");
@@ -3443,7 +3597,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3469,33 +3623,33 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var ResultHeader = function (_React$Component) {
-	_inherits(ResultHeader, _React$Component);
+  _inherits(ResultHeader, _React$Component);
 
-	function ResultHeader() {
-		_classCallCheck(this, ResultHeader);
+  function ResultHeader() {
+    _classCallCheck(this, ResultHeader);
 
-		return _possibleConstructorReturn(this, (ResultHeader.__proto__ || Object.getPrototypeOf(ResultHeader)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (ResultHeader.__proto__ || Object.getPrototypeOf(ResultHeader)).apply(this, arguments));
+  }
 
-	_createClass(ResultHeader, [{
-		key: "render",
-		value: function render() {
-			var bootstrapCss = this.props.bootstrapCss;
+  _createClass(ResultHeader, [{
+    key: "render",
+    value: function render() {
+      var bootstrapCss = this.props.bootstrapCss;
 
-			return _react2.default.createElement(
-				"div",
-				{ className: (0, _classnames2.default)({ "panel-heading": bootstrapCss }) },
-				this.props.children
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "div",
+        { className: (0, _classnames2.default)({ "panel-heading": bootstrapCss }) },
+        this.props.children
+      );
+    }
+  }]);
 
-	return ResultHeader;
+  return ResultHeader;
 }(_react2.default.Component);
 
 ResultHeader.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	children: _propTypes2.default.array
+  bootstrapCss: _propTypes2.default.bool,
+  children: _propTypes2.default.array
 };
 
 exports.default = ResultHeader;
@@ -3504,7 +3658,7 @@ exports.default = ResultHeader;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3530,33 +3684,33 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var ResultList = function (_React$Component) {
-	_inherits(ResultList, _React$Component);
+  _inherits(ResultList, _React$Component);
 
-	function ResultList() {
-		_classCallCheck(this, ResultList);
+  function ResultList() {
+    _classCallCheck(this, ResultList);
 
-		return _possibleConstructorReturn(this, (ResultList.__proto__ || Object.getPrototypeOf(ResultList)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (ResultList.__proto__ || Object.getPrototypeOf(ResultList)).apply(this, arguments));
+  }
 
-	_createClass(ResultList, [{
-		key: "render",
-		value: function render() {
-			var bootstrapCss = this.props.bootstrapCss;
+  _createClass(ResultList, [{
+    key: "render",
+    value: function render() {
+      var bootstrapCss = this.props.bootstrapCss;
 
-			return _react2.default.createElement(
-				"ul",
-				{ className: (0, _classnames2.default)({ "list-group": bootstrapCss }) },
-				this.props.children
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "ul",
+        { className: (0, _classnames2.default)({ "list-group": bootstrapCss }) },
+        this.props.children
+      );
+    }
+  }]);
 
-	return ResultList;
+  return ResultList;
 }(_react2.default.Component);
 
 ResultList.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	children: _propTypes2.default.array
+  bootstrapCss: _propTypes2.default.bool,
+  children: _propTypes2.default.array
 };
 
 exports.default = ResultList;
@@ -3565,7 +3719,7 @@ exports.default = ResultList;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3591,126 +3745,126 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Pagination = function (_React$Component) {
-	_inherits(Pagination, _React$Component);
+  _inherits(Pagination, _React$Component);
 
-	function Pagination() {
-		_classCallCheck(this, Pagination);
+  function Pagination() {
+    _classCallCheck(this, Pagination);
 
-		return _possibleConstructorReturn(this, (Pagination.__proto__ || Object.getPrototypeOf(Pagination)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (Pagination.__proto__ || Object.getPrototypeOf(Pagination)).apply(this, arguments));
+  }
 
-	_createClass(Pagination, [{
-		key: "onPageChange",
-		value: function onPageChange(page, pageAmt) {
-			if (page >= pageAmt || page < 0) {
-				return;
-			}
-			this.props.onChange(page);
-		}
-	}, {
-		key: "renderPage",
-		value: function renderPage(page, currentPage, key) {
-			return _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)({ "active": page === currentPage }), key: key },
-				_react2.default.createElement(
-					"a",
-					{ onClick: this.onPageChange.bind(this, page) },
-					page + 1
-				)
-			);
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _this2 = this;
+  _createClass(Pagination, [{
+    key: "onPageChange",
+    value: function onPageChange(page, pageAmt) {
+      if (page >= pageAmt || page < 0) {
+        return;
+      }
+      this.props.onChange(page);
+    }
+  }, {
+    key: "renderPage",
+    value: function renderPage(page, currentPage, key) {
+      return _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)({ "active": page === currentPage }), key: key },
+        _react2.default.createElement(
+          "a",
+          { onClick: this.onPageChange.bind(this, page) },
+          page + 1
+        )
+      );
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
 
-			var _props = this.props,
-			    bootstrapCss = _props.bootstrapCss,
-			    query = _props.query,
-			    results = _props.results;
-			var start = query.start,
-			    rows = query.rows;
-			var numFound = results.numFound;
+      var _props = this.props,
+          bootstrapCss = _props.bootstrapCss,
+          query = _props.query,
+          results = _props.results;
+      var start = query.start,
+          rows = query.rows;
+      var numFound = results.numFound;
 
-			var pageAmt = Math.ceil(numFound / rows);
-			var currentPage = start / rows;
+      var pageAmt = Math.ceil(numFound / rows);
+      var currentPage = start / rows;
 
-			var rangeStart = currentPage - 2 < 0 ? 0 : currentPage - 2;
-			var rangeEnd = rangeStart + 5 > pageAmt ? pageAmt : rangeStart + 5;
+      var rangeStart = currentPage - 2 < 0 ? 0 : currentPage - 2;
+      var rangeEnd = rangeStart + 5 > pageAmt ? pageAmt : rangeStart + 5;
 
-			if (rangeEnd - rangeStart < 5 && rangeStart > 0) {
-				rangeStart = rangeEnd - 5;
-				if (rangeStart < 0) {
-					rangeStart = 0;
-				}
-			}
+      if (rangeEnd - rangeStart < 5 && rangeStart > 0) {
+        rangeStart = rangeEnd - 5;
+        if (rangeStart < 0) {
+          rangeStart = 0;
+        }
+      }
 
-			var pages = [];
-			for (var page = rangeStart; page < rangeEnd; page++) {
-				if (pages.indexOf(page) < 0) {
-					pages.push(page);
-				}
-			}
+      var pages = [];
+      for (var page = rangeStart; page < rangeEnd; page++) {
+        if (pages.indexOf(page) < 0) {
+          pages.push(page);
+        }
+      }
 
-			return _react2.default.createElement(
-				"div",
-				{ className: (0, _classnames2.default)({ "panel-body": bootstrapCss, "text-center": bootstrapCss }) },
-				_react2.default.createElement(
-					"ul",
-					{ className: (0, _classnames2.default)("pagination", { "pagination-sm": bootstrapCss }) },
-					_react2.default.createElement(
-						"li",
-						{ className: (0, _classnames2.default)({ "disabled": currentPage === 0 }), key: "start" },
-						_react2.default.createElement(
-							"a",
-							{ onClick: this.onPageChange.bind(this, 0) },
-							"<<"
-						)
-					),
-					_react2.default.createElement(
-						"li",
-						{ className: (0, _classnames2.default)({ "disabled": currentPage - 1 < 0 }), key: "prev" },
-						_react2.default.createElement(
-							"a",
-							{ onClick: this.onPageChange.bind(this, currentPage - 1) },
-							"<"
-						)
-					),
-					pages.map(function (page, idx) {
-						return _this2.renderPage(page, currentPage, idx);
-					}),
-					_react2.default.createElement(
-						"li",
-						{ className: (0, _classnames2.default)({ "disabled": currentPage + 1 >= pageAmt }), key: "next" },
-						_react2.default.createElement(
-							"a",
-							{ onClick: this.onPageChange.bind(this, currentPage + 1, pageAmt) },
-							">"
-						)
-					),
-					_react2.default.createElement(
-						"li",
-						{ className: (0, _classnames2.default)({ "disabled": currentPage === pageAmt - 1 }), key: "end" },
-						_react2.default.createElement(
-							"a",
-							{ onClick: this.onPageChange.bind(this, pageAmt - 1) },
-							">>"
-						)
-					)
-				)
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "div",
+        { className: (0, _classnames2.default)({ "panel-body": bootstrapCss, "text-center": bootstrapCss }) },
+        _react2.default.createElement(
+          "ul",
+          { className: (0, _classnames2.default)("pagination", { "pagination-sm": bootstrapCss }) },
+          _react2.default.createElement(
+            "li",
+            { className: (0, _classnames2.default)({ "disabled": currentPage === 0 }), key: "start" },
+            _react2.default.createElement(
+              "a",
+              { onClick: this.onPageChange.bind(this, 0) },
+              "<<"
+            )
+          ),
+          _react2.default.createElement(
+            "li",
+            { className: (0, _classnames2.default)({ "disabled": currentPage - 1 < 0 }), key: "prev" },
+            _react2.default.createElement(
+              "a",
+              { onClick: this.onPageChange.bind(this, currentPage - 1) },
+              "<"
+            )
+          ),
+          pages.map(function (page, idx) {
+            return _this2.renderPage(page, currentPage, idx);
+          }),
+          _react2.default.createElement(
+            "li",
+            { className: (0, _classnames2.default)({ "disabled": currentPage + 1 >= pageAmt }), key: "next" },
+            _react2.default.createElement(
+              "a",
+              { onClick: this.onPageChange.bind(this, currentPage + 1, pageAmt) },
+              ">"
+            )
+          ),
+          _react2.default.createElement(
+            "li",
+            { className: (0, _classnames2.default)({ "disabled": currentPage === pageAmt - 1 }), key: "end" },
+            _react2.default.createElement(
+              "a",
+              { onClick: this.onPageChange.bind(this, pageAmt - 1) },
+              ">>"
+            )
+          )
+        )
+      );
+    }
+  }]);
 
-	return Pagination;
+  return Pagination;
 }(_react2.default.Component);
 
 Pagination.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	onChange: _propTypes2.default.func,
-	query: _propTypes2.default.object,
-	results: _propTypes2.default.object
+  bootstrapCss: _propTypes2.default.bool,
+  onChange: _propTypes2.default.func,
+  query: _propTypes2.default.object,
+  results: _propTypes2.default.object
 };
 
 exports.default = Pagination;
@@ -3719,7 +3873,7 @@ exports.default = Pagination;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3741,30 +3895,30 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Pending = function (_React$Component) {
-	_inherits(Pending, _React$Component);
+  _inherits(Pending, _React$Component);
 
-	function Pending() {
-		_classCallCheck(this, Pending);
+  function Pending() {
+    _classCallCheck(this, Pending);
 
-		return _possibleConstructorReturn(this, (Pending.__proto__ || Object.getPrototypeOf(Pending)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (Pending.__proto__ || Object.getPrototypeOf(Pending)).apply(this, arguments));
+  }
 
-	_createClass(Pending, [{
-		key: "render",
-		value: function render() {
-			return _react2.default.createElement(
-				"span",
-				null,
-				"Waiting for results"
-			);
-		}
-	}]);
+  _createClass(Pending, [{
+    key: "render",
+    value: function render() {
+      return _react2.default.createElement(
+        "span",
+        null,
+        "Waiting for results"
+      );
+    }
+  }]);
 
-	return Pending;
+  return Pending;
 }(_react2.default.Component);
 
 Pending.propTypes = {
-	bootstrapCss: _propTypes2.default.bool
+  bootstrapCss: _propTypes2.default.bool
 };
 
 exports.default = Pending;
@@ -3773,7 +3927,7 @@ exports.default = Pending;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3803,71 +3957,71 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var PreloadIndicator = function (_React$Component) {
-	_inherits(PreloadIndicator, _React$Component);
+  _inherits(PreloadIndicator, _React$Component);
 
-	function PreloadIndicator(props) {
-		_classCallCheck(this, PreloadIndicator);
+  function PreloadIndicator(props) {
+    _classCallCheck(this, PreloadIndicator);
 
-		var _this = _possibleConstructorReturn(this, (PreloadIndicator.__proto__ || Object.getPrototypeOf(PreloadIndicator)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (PreloadIndicator.__proto__ || Object.getPrototypeOf(PreloadIndicator)).call(this, props));
 
-		_this.scrollListener = _this.onWindowScroll.bind(_this);
-		return _this;
-	}
+    _this.scrollListener = _this.onWindowScroll.bind(_this);
+    return _this;
+  }
 
-	_createClass(PreloadIndicator, [{
-		key: "componentDidMount",
-		value: function componentDidMount() {
-			window.addEventListener("scroll", this.scrollListener);
-		}
-	}, {
-		key: "componentWillUnmount",
-		value: function componentWillUnmount() {
-			window.removeEventListener("scroll", this.scrollListener);
-		}
-	}, {
-		key: "onWindowScroll",
-		value: function onWindowScroll() {
-			var pageStrategy = this.props.query.pageStrategy;
-			var pending = this.props.results.pending;
+  _createClass(PreloadIndicator, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      window.addEventListener("scroll", this.scrollListener);
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      window.removeEventListener("scroll", this.scrollListener);
+    }
+  }, {
+    key: "onWindowScroll",
+    value: function onWindowScroll() {
+      var pageStrategy = this.props.query.pageStrategy;
+      var pending = this.props.results.pending;
 
 
-			if (pageStrategy !== "cursor" || pending) {
-				return;
-			}
+      if (pageStrategy !== "cursor" || pending) {
+        return;
+      }
 
-			var domNode = _reactDom2.default.findDOMNode(this);
-			if (!domNode) {
-				return;
-			}
+      var domNode = _reactDom2.default.findDOMNode(this);
+      if (!domNode) {
+        return;
+      }
 
-			var _domNode$getBoundingC = domNode.getBoundingClientRect(),
-			    top = _domNode$getBoundingC.top;
+      var _domNode$getBoundingC = domNode.getBoundingClientRect(),
+          top = _domNode$getBoundingC.top;
 
-			if (top < window.innerHeight) {
-				this.props.onNextCursorQuery();
-			}
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var bootstrapCss = this.props.bootstrapCss;
+      if (top < window.innerHeight) {
+        this.props.onNextCursorQuery();
+      }
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var bootstrapCss = this.props.bootstrapCss;
 
-			return _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)("fetch-by-cursor", { "list-group-item": bootstrapCss }) },
-				"Loading more..."
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)("fetch-by-cursor", { "list-group-item": bootstrapCss }) },
+        "Loading more..."
+      );
+    }
+  }]);
 
-	return PreloadIndicator;
+  return PreloadIndicator;
 }(_react2.default.Component);
 
 PreloadIndicator.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	onNextCursorQuery: _propTypes2.default.func,
-	query: _propTypes2.default.object,
-	results: _propTypes2.default.object
+  bootstrapCss: _propTypes2.default.bool,
+  onNextCursorQuery: _propTypes2.default.func,
+  query: _propTypes2.default.object,
+  results: _propTypes2.default.object
 };
 
 exports.default = PreloadIndicator;
@@ -3876,7 +4030,7 @@ exports.default = PreloadIndicator;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3902,69 +4056,69 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Result = function (_React$Component) {
-	_inherits(Result, _React$Component);
+  _inherits(Result, _React$Component);
 
-	function Result() {
-		_classCallCheck(this, Result);
+  function Result() {
+    _classCallCheck(this, Result);
 
-		return _possibleConstructorReturn(this, (Result.__proto__ || Object.getPrototypeOf(Result)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (Result.__proto__ || Object.getPrototypeOf(Result)).apply(this, arguments));
+  }
 
-	_createClass(Result, [{
-		key: "renderValue",
-		value: function renderValue(field, doc) {
-			var value = [].concat(doc[field] || null).filter(function (v) {
-				return v !== null;
-			});
+  _createClass(Result, [{
+    key: "renderValue",
+    value: function renderValue(field, doc) {
+      var value = [].concat(doc[field] || null).filter(function (v) {
+        return v !== null;
+      });
 
-			return value.join(", ");
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _this2 = this;
+      return value.join(", ");
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
 
-			var _props = this.props,
-			    bootstrapCss = _props.bootstrapCss,
-			    doc = _props.doc,
-			    fields = _props.fields;
+      var _props = this.props,
+          bootstrapCss = _props.bootstrapCss,
+          doc = _props.doc,
+          fields = _props.fields;
 
 
-			return _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), onClick: function onClick() {
-						return _this2.props.onSelect(doc);
-					} },
-				_react2.default.createElement(
-					"ul",
-					null,
-					fields.filter(function (field) {
-						return field.field !== "*";
-					}).map(function (field, i) {
-						return _react2.default.createElement(
-							"li",
-							{ key: i },
-							_react2.default.createElement(
-								"label",
-								null,
-								field.label || field.field
-							),
-							_this2.renderValue(field.field, doc)
-						);
-					})
-				)
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }), onClick: function onClick() {
+            return _this2.props.onSelect(doc);
+          } },
+        _react2.default.createElement(
+          "ul",
+          null,
+          fields.filter(function (field) {
+            return field.field !== "*";
+          }).map(function (field, i) {
+            return _react2.default.createElement(
+              "li",
+              { key: i },
+              _react2.default.createElement(
+                "label",
+                null,
+                field.label || field.field
+              ),
+              _this2.renderValue(field.field, doc)
+            );
+          })
+        )
+      );
+    }
+  }]);
 
-	return Result;
+  return Result;
 }(_react2.default.Component);
 
 Result.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	doc: _propTypes2.default.object,
-	fields: _propTypes2.default.array,
-	onSelect: _propTypes2.default.func.isRequired
+  bootstrapCss: _propTypes2.default.bool,
+  doc: _propTypes2.default.object,
+  fields: _propTypes2.default.array,
+  onSelect: _propTypes2.default.func.isRequired
 };
 
 exports.default = Result;
@@ -3973,7 +4127,7 @@ exports.default = Result;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -3999,59 +4153,64 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var SearchFieldContainer = function (_React$Component) {
-	_inherits(SearchFieldContainer, _React$Component);
+  _inherits(SearchFieldContainer, _React$Component);
 
-	function SearchFieldContainer() {
-		_classCallCheck(this, SearchFieldContainer);
+  function SearchFieldContainer() {
+    _classCallCheck(this, SearchFieldContainer);
 
-		return _possibleConstructorReturn(this, (SearchFieldContainer.__proto__ || Object.getPrototypeOf(SearchFieldContainer)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (SearchFieldContainer.__proto__ || Object.getPrototypeOf(SearchFieldContainer)).apply(this, arguments));
+  }
 
-	_createClass(SearchFieldContainer, [{
-		key: "render",
-		value: function render() {
-			var _props = this.props,
-			    bootstrapCss = _props.bootstrapCss,
-			    onNewSearch = _props.onNewSearch;
+  _createClass(SearchFieldContainer, [{
+    key: "render",
+    value: function render() {
+      var _props = this.props,
+          bootstrapCss = _props.bootstrapCss,
+          onNewSearch = _props.onNewSearch;
 
-			return _react2.default.createElement(
-				"div",
-				{ className: (0, _classnames2.default)({ "col-md-3": bootstrapCss }) },
-				_react2.default.createElement(
-					"div",
-					{ className: (0, _classnames2.default)({ "panel": bootstrapCss, "panel-default": bootstrapCss }) },
-					_react2.default.createElement(
-						"header",
-						{ className: (0, _classnames2.default)({ "panel-heading": bootstrapCss }) },
-						_react2.default.createElement(
-							"button",
-							{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss, "pull-right": bootstrapCss }),
-								onClick: onNewSearch },
-							"New search"
-						),
-						_react2.default.createElement(
-							"label",
-							null,
-							"Search"
-						)
-					),
-					_react2.default.createElement(
-						"ul",
-						{ className: (0, _classnames2.default)("solr-search-fields", { "list-group": bootstrapCss }) },
-						this.props.children
-					)
-				)
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "div",
+        { className: (0, _classnames2.default)({ "col-md-3": bootstrapCss }) },
+        _react2.default.createElement(
+          "div",
+          { className: (0, _classnames2.default)({ "panel": bootstrapCss, "panel-default": bootstrapCss }) },
+          _react2.default.createElement(
+            "header",
+            { className: (0, _classnames2.default)({ "panel-heading": bootstrapCss }) },
+            _react2.default.createElement(
+              "button",
+              { className: (0, _classnames2.default)({
+                  "btn": bootstrapCss,
+                  "btn-default": bootstrapCss,
+                  "btn-xs": bootstrapCss,
+                  "pull-right": bootstrapCss
+                }),
+                onClick: onNewSearch },
+              "New search"
+            ),
+            _react2.default.createElement(
+              "label",
+              null,
+              "Search"
+            )
+          ),
+          _react2.default.createElement(
+            "ul",
+            { className: (0, _classnames2.default)("solr-search-fields", { "list-group": bootstrapCss }) },
+            this.props.children
+          )
+        )
+      );
+    }
+  }]);
 
-	return SearchFieldContainer;
+  return SearchFieldContainer;
 }(_react2.default.Component);
 
 SearchFieldContainer.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	children: _propTypes2.default.array,
-	onNewSearch: _propTypes2.default.func
+  bootstrapCss: _propTypes2.default.bool,
+  children: _propTypes2.default.array,
+  onNewSearch: _propTypes2.default.func
 };
 
 exports.default = SearchFieldContainer;
@@ -4060,7 +4219,7 @@ exports.default = SearchFieldContainer;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -4092,144 +4251,144 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var getFacetValues = function getFacetValues(type, results, field, lowerBound, upperBound) {
-	return type === "period-range-facet" ? (results.facets[lowerBound] || []).concat(results.facets[upperBound] || []) : type === "list-facet" || type === "range-facet" ? results.facets[field] || [] : null;
+  return type === "period-range-facet" ? (results.facets[lowerBound] || []).concat(results.facets[upperBound] || []) : type === "list-facet" || type === "range-facet" ? results.facets[field] || [] : null;
 };
 
 var SolrFacetedSearch = function (_React$Component) {
-	_inherits(SolrFacetedSearch, _React$Component);
+  _inherits(SolrFacetedSearch, _React$Component);
 
-	function SolrFacetedSearch() {
-		_classCallCheck(this, SolrFacetedSearch);
+  function SolrFacetedSearch() {
+    _classCallCheck(this, SolrFacetedSearch);
 
-		return _possibleConstructorReturn(this, (SolrFacetedSearch.__proto__ || Object.getPrototypeOf(SolrFacetedSearch)).apply(this, arguments));
-	}
+    return _possibleConstructorReturn(this, (SolrFacetedSearch.__proto__ || Object.getPrototypeOf(SolrFacetedSearch)).apply(this, arguments));
+  }
 
-	_createClass(SolrFacetedSearch, [{
-		key: "render",
-		value: function render() {
-			var _this2 = this;
+  _createClass(SolrFacetedSearch, [{
+    key: "render",
+    value: function render() {
+      var _this2 = this;
 
-			var _props = this.props,
-			    customComponents = _props.customComponents,
-			    bootstrapCss = _props.bootstrapCss,
-			    query = _props.query,
-			    results = _props.results,
-			    truncateFacetListsAt = _props.truncateFacetListsAt;
-			var _props2 = this.props,
-			    onSearchFieldChange = _props2.onSearchFieldChange,
-			    onSortFieldChange = _props2.onSortFieldChange,
-			    onPageChange = _props2.onPageChange,
-			    onCsvExport = _props2.onCsvExport;
-			var searchFields = query.searchFields,
-			    sortFields = query.sortFields,
-			    start = query.start,
-			    rows = query.rows;
+      var _props = this.props,
+          customComponents = _props.customComponents,
+          bootstrapCss = _props.bootstrapCss,
+          query = _props.query,
+          results = _props.results,
+          truncateFacetListsAt = _props.truncateFacetListsAt;
+      var _props2 = this.props,
+          onSearchFieldChange = _props2.onSearchFieldChange,
+          onSortFieldChange = _props2.onSortFieldChange,
+          onPageChange = _props2.onPageChange,
+          onCsvExport = _props2.onCsvExport;
+      var searchFields = query.searchFields,
+          sortFields = query.sortFields,
+          start = query.start,
+          rows = query.rows;
 
 
-			var SearchFieldContainerComponent = customComponents.searchFields.container;
-			var ResultContainerComponent = customComponents.results.container;
+      var SearchFieldContainerComponent = customComponents.searchFields.container;
+      var ResultContainerComponent = customComponents.results.container;
 
-			var ResultComponent = customComponents.results.result;
-			var ResultCount = customComponents.results.resultCount;
-			var ResultHeaderComponent = customComponents.results.header;
-			var ResultListComponent = customComponents.results.list;
-			var ResultPendingComponent = customComponents.results.pending;
-			var PaginateComponent = customComponents.results.paginate;
-			var PreloadComponent = customComponents.results.preloadIndicator;
-			var CsvExportComponent = customComponents.results.csvExport;
-			var CurrentQueryComponent = customComponents.searchFields.currentQuery;
-			var SortComponent = customComponents.sortFields.menu;
-			var resultPending = results.pending ? _react2.default.createElement(ResultPendingComponent, { bootstrapCss: bootstrapCss }) : null;
+      var ResultComponent = customComponents.results.result;
+      var ResultCount = customComponents.results.resultCount;
+      var ResultHeaderComponent = customComponents.results.header;
+      var ResultListComponent = customComponents.results.list;
+      var ResultPendingComponent = customComponents.results.pending;
+      var PaginateComponent = customComponents.results.paginate;
+      var PreloadComponent = customComponents.results.preloadIndicator;
+      var CsvExportComponent = customComponents.results.csvExport;
+      var CurrentQueryComponent = customComponents.searchFields.currentQuery;
+      var SortComponent = customComponents.sortFields.menu;
+      var resultPending = results.pending ? _react2.default.createElement(ResultPendingComponent, { bootstrapCss: bootstrapCss }) : null;
 
-			var pagination = query.pageStrategy === "paginate" ? _react2.default.createElement(PaginateComponent, _extends({}, this.props, { bootstrapCss: bootstrapCss, onChange: onPageChange })) : null;
+      var pagination = query.pageStrategy === "paginate" ? _react2.default.createElement(PaginateComponent, _extends({}, this.props, { bootstrapCss: bootstrapCss, onChange: onPageChange })) : null;
 
-			var preloadListItem = query.pageStrategy === "cursor" && results.docs.length < results.numFound ? _react2.default.createElement(PreloadComponent, this.props) : null;
+      var preloadListItem = query.pageStrategy === "cursor" && results.docs.length < results.numFound ? _react2.default.createElement(PreloadComponent, this.props) : null;
 
-			return _react2.default.createElement(
-				"div",
-				{ className: (0, _classnames2.default)("solr-faceted-search", { "container": bootstrapCss, "col-md-12": bootstrapCss }) },
-				_react2.default.createElement(
-					SearchFieldContainerComponent,
-					{ bootstrapCss: bootstrapCss, onNewSearch: this.props.onNewSearch },
-					searchFields.map(function (searchField, i) {
-						var type = searchField.type,
-						    field = searchField.field,
-						    lowerBound = searchField.lowerBound,
-						    upperBound = searchField.upperBound;
+      return _react2.default.createElement(
+        "div",
+        { className: (0, _classnames2.default)("solr-faceted-search", { "container": bootstrapCss, "col-md-12": bootstrapCss }) },
+        _react2.default.createElement(
+          SearchFieldContainerComponent,
+          { bootstrapCss: bootstrapCss, onNewSearch: this.props.onNewSearch },
+          searchFields.map(function (searchField, i) {
+            var type = searchField.type,
+                field = searchField.field,
+                lowerBound = searchField.lowerBound,
+                upperBound = searchField.upperBound;
 
-						var SearchComponent = customComponents.searchFields[type];
-						var facets = getFacetValues(type, results, field, lowerBound, upperBound);
+            var SearchComponent = customComponents.searchFields[type];
+            var facets = getFacetValues(type, results, field, lowerBound, upperBound);
 
-						return _react2.default.createElement(SearchComponent, _extends({
-							key: i }, _this2.props, searchField, {
-							bootstrapCss: bootstrapCss,
-							facets: facets,
-							truncateFacetListsAt: truncateFacetListsAt,
-							onChange: onSearchFieldChange }));
-					})
-				),
-				_react2.default.createElement(
-					ResultContainerComponent,
-					{ bootstrapCss: bootstrapCss },
-					_react2.default.createElement(
-						ResultHeaderComponent,
-						{ bootstrapCss: bootstrapCss },
-						_react2.default.createElement(ResultCount, { bootstrapCss: bootstrapCss, numFound: results.numFound }),
-						resultPending,
-						_react2.default.createElement(SortComponent, { bootstrapCss: bootstrapCss, onChange: onSortFieldChange, sortFields: sortFields }),
-						this.props.showCsvExport ? _react2.default.createElement(CsvExportComponent, { bootstrapCss: bootstrapCss, onClick: onCsvExport }) : null
-					),
-					_react2.default.createElement(CurrentQueryComponent, _extends({}, this.props, { onChange: onSearchFieldChange })),
-					pagination,
-					_react2.default.createElement(
-						ResultListComponent,
-						{ bootstrapCss: bootstrapCss },
-						results.docs.map(function (doc, i) {
-							return _react2.default.createElement(ResultComponent, { bootstrapCss: bootstrapCss,
-								doc: doc,
-								fields: searchFields,
-								key: doc.id || i,
-								onSelect: _this2.props.onSelectDoc,
-								resultIndex: i,
-								rows: rows,
-								start: start
-							});
-						}),
-						preloadListItem
-					),
-					pagination
-				)
-			);
-		}
-	}]);
+            return _react2.default.createElement(SearchComponent, _extends({
+              key: i }, _this2.props, searchField, {
+              bootstrapCss: bootstrapCss,
+              facets: facets,
+              truncateFacetListsAt: truncateFacetListsAt,
+              onChange: onSearchFieldChange }));
+          })
+        ),
+        _react2.default.createElement(
+          ResultContainerComponent,
+          { bootstrapCss: bootstrapCss },
+          _react2.default.createElement(
+            ResultHeaderComponent,
+            { bootstrapCss: bootstrapCss },
+            _react2.default.createElement(ResultCount, { bootstrapCss: bootstrapCss, numFound: results.numFound }),
+            resultPending,
+            _react2.default.createElement(SortComponent, { bootstrapCss: bootstrapCss, onChange: onSortFieldChange, sortFields: sortFields }),
+            this.props.showCsvExport ? _react2.default.createElement(CsvExportComponent, { bootstrapCss: bootstrapCss, onClick: onCsvExport }) : null
+          ),
+          _react2.default.createElement(CurrentQueryComponent, _extends({}, this.props, { onChange: onSearchFieldChange })),
+          pagination,
+          _react2.default.createElement(
+            ResultListComponent,
+            { bootstrapCss: bootstrapCss },
+            results.docs.map(function (doc, i) {
+              return _react2.default.createElement(ResultComponent, { bootstrapCss: bootstrapCss,
+                doc: doc,
+                fields: searchFields,
+                key: doc.id || i,
+                onSelect: _this2.props.onSelectDoc,
+                resultIndex: i,
+                rows: rows,
+                start: start
+              });
+            }),
+            preloadListItem
+          ),
+          pagination
+        )
+      );
+    }
+  }]);
 
-	return SolrFacetedSearch;
+  return SolrFacetedSearch;
 }(_react2.default.Component);
 
 SolrFacetedSearch.defaultProps = {
-	bootstrapCss: true,
-	customComponents: _componentPack2.default,
-	pageStrategy: "paginate",
-	rows: 20,
-	searchFields: [{ type: "text", field: "*" }],
-	sortFields: [],
-	truncateFacetListsAt: -1,
-	showCsvExport: false
+  bootstrapCss: true,
+  customComponents: _componentPack2.default,
+  pageStrategy: "paginate",
+  rows: 20,
+  searchFields: [{ type: "text", field: "*" }],
+  sortFields: [],
+  truncateFacetListsAt: -1,
+  showCsvExport: false
 };
 
 SolrFacetedSearch.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	customComponents: _propTypes2.default.object,
-	onCsvExport: _propTypes2.default.func,
-	onNewSearch: _propTypes2.default.func,
-	onPageChange: _propTypes2.default.func,
-	onSearchFieldChange: _propTypes2.default.func.isRequired,
-	onSelectDoc: _propTypes2.default.func,
-	onSortFieldChange: _propTypes2.default.func.isRequired,
-	query: _propTypes2.default.object,
-	results: _propTypes2.default.object,
-	showCsvExport: _propTypes2.default.bool,
-	truncateFacetListsAt: _propTypes2.default.number
+  bootstrapCss: _propTypes2.default.bool,
+  customComponents: _propTypes2.default.object,
+  onCsvExport: _propTypes2.default.func,
+  onNewSearch: _propTypes2.default.func,
+  onPageChange: _propTypes2.default.func,
+  onSearchFieldChange: _propTypes2.default.func.isRequired,
+  onSelectDoc: _propTypes2.default.func,
+  onSortFieldChange: _propTypes2.default.func.isRequired,
+  query: _propTypes2.default.object,
+  results: _propTypes2.default.object,
+  showCsvExport: _propTypes2.default.bool,
+  truncateFacetListsAt: _propTypes2.default.number
 };
 
 exports.default = SolrFacetedSearch;
@@ -4238,7 +4397,7 @@ exports.default = SolrFacetedSearch;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -4268,151 +4427,168 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var SortMenu = function (_React$Component) {
-	_inherits(SortMenu, _React$Component);
+  _inherits(SortMenu, _React$Component);
 
-	function SortMenu(props) {
-		_classCallCheck(this, SortMenu);
+  function SortMenu(props) {
+    _classCallCheck(this, SortMenu);
 
-		var _this = _possibleConstructorReturn(this, (SortMenu.__proto__ || Object.getPrototypeOf(SortMenu)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (SortMenu.__proto__ || Object.getPrototypeOf(SortMenu)).call(this, props));
 
-		_this.state = {
-			isOpen: false
-		};
-		_this.documentClickListener = _this.handleDocumentClick.bind(_this);
-		return _this;
-	}
+    _this.state = {
+      isOpen: false
+    };
+    _this.documentClickListener = _this.handleDocumentClick.bind(_this);
+    return _this;
+  }
 
-	_createClass(SortMenu, [{
-		key: "componentDidMount",
-		value: function componentDidMount() {
-			document.addEventListener("click", this.documentClickListener, false);
-		}
-	}, {
-		key: "componentWillUnmount",
-		value: function componentWillUnmount() {
-			document.removeEventListener("click", this.documentClickListener, false);
-		}
-	}, {
-		key: "toggleSelect",
-		value: function toggleSelect() {
-			if (this.state.isOpen) {
-				this.setState({ isOpen: false });
-			} else {
-				this.setState({ isOpen: true });
-			}
-		}
-	}, {
-		key: "onSelect",
-		value: function onSelect(sortField) {
-			var foundIdx = this.props.sortFields.indexOf(sortField);
-			if (foundIdx < 0) {
-				this.props.onChange(sortField, "asc");
-			} else {
-				this.props.onChange(sortField, null);
-			}
-		}
-	}, {
-		key: "handleDocumentClick",
-		value: function handleDocumentClick(ev) {
-			var isOpen = this.state.isOpen;
+  _createClass(SortMenu, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      document.addEventListener("click", this.documentClickListener, false);
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      document.removeEventListener("click", this.documentClickListener, false);
+    }
+  }, {
+    key: "toggleSelect",
+    value: function toggleSelect() {
+      if (this.state.isOpen) {
+        this.setState({ isOpen: false });
+      } else {
+        this.setState({ isOpen: true });
+      }
+    }
+  }, {
+    key: "onSelect",
+    value: function onSelect(sortField) {
+      var foundIdx = this.props.sortFields.indexOf(sortField);
+      if (foundIdx < 0) {
+        this.props.onChange(sortField, "asc");
+      } else {
+        this.props.onChange(sortField, null);
+      }
+    }
+  }, {
+    key: "handleDocumentClick",
+    value: function handleDocumentClick(ev) {
+      var isOpen = this.state.isOpen;
 
-			if (isOpen && !_reactDom2.default.findDOMNode(this).contains(ev.target)) {
-				this.setState({
-					isOpen: false
-				});
-			}
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _this2 = this;
+      if (isOpen && !_reactDom2.default.findDOMNode(this).contains(ev.target)) {
+        this.setState({
+          isOpen: false
+        });
+      }
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
 
-			var _props = this.props,
-			    bootstrapCss = _props.bootstrapCss,
-			    sortFields = _props.sortFields;
+      var _props = this.props,
+          bootstrapCss = _props.bootstrapCss,
+          sortFields = _props.sortFields;
 
-			if (sortFields.length === 0) {
-				return null;
-			}
+      if (sortFields.length === 0) {
+        return null;
+      }
 
-			var value = sortFields.find(function (sf) {
-				return sf.value;
-			});
+      var value = sortFields.find(function (sf) {
+        return sf.value;
+      });
 
-			return _react2.default.createElement(
-				"span",
-				{ className: (0, _classnames2.default)({ "pull-right": bootstrapCss }) },
-				_react2.default.createElement(
-					"span",
-					{ className: (0, _classnames2.default)({ "dropdown": bootstrapCss, "open": this.state.isOpen }) },
-					_react2.default.createElement(
-						"button",
-						{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss, "dropdown-toggle": bootstrapCss }),
-							onClick: this.toggleSelect.bind(this) },
-						value ? value.label : "- select sort -",
-						" ",
-						_react2.default.createElement("span", { className: "caret" })
-					),
-					_react2.default.createElement(
-						"ul",
-						{ className: "dropdown-menu" },
-						sortFields.map(function (sortField, i) {
-							return _react2.default.createElement(
-								"li",
-								{ key: i },
-								_react2.default.createElement(
-									"a",
-									{ onClick: function onClick() {
-											_this2.onSelect(sortField.field);_this2.toggleSelect();
-										} },
-									sortField.label
-								)
-							);
-						}),
-						value ? _react2.default.createElement(
-							"li",
-							null,
-							_react2.default.createElement(
-								"a",
-								{ onClick: function onClick() {
-										_this2.props.onChange(value.field, null);_this2.toggleSelect();
-									} },
-								"- clear -"
-							)
-						) : null
-					)
-				),
-				value ? _react2.default.createElement(
-					"span",
-					{ className: (0, _classnames2.default)({ "btn-group": bootstrapCss }) },
-					_react2.default.createElement(
-						"button",
-						{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss, active: value.value === "asc" }),
-							onClick: function onClick() {
-								return _this2.props.onChange(value.field, "asc");
-							} },
-						"asc"
-					),
-					_react2.default.createElement(
-						"button",
-						{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-xs": bootstrapCss, active: value.value === "desc" }),
-							onClick: function onClick() {
-								return _this2.props.onChange(value.field, "desc");
-							} },
-						"desc"
-					)
-				) : null
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "span",
+        { className: (0, _classnames2.default)({ "pull-right": bootstrapCss }) },
+        _react2.default.createElement(
+          "span",
+          { className: (0, _classnames2.default)({ "dropdown": bootstrapCss, "open": this.state.isOpen }) },
+          _react2.default.createElement(
+            "button",
+            { className: (0, _classnames2.default)({
+                "btn": bootstrapCss,
+                "btn-default": bootstrapCss,
+                "btn-xs": bootstrapCss,
+                "dropdown-toggle": bootstrapCss
+              }),
+              onClick: this.toggleSelect.bind(this) },
+            value ? value.label : "- select sort -",
+            " ",
+            _react2.default.createElement("span", { className: "caret" })
+          ),
+          _react2.default.createElement(
+            "ul",
+            { className: "dropdown-menu" },
+            sortFields.map(function (sortField, i) {
+              return _react2.default.createElement(
+                "li",
+                { key: i },
+                _react2.default.createElement(
+                  "a",
+                  { onClick: function onClick() {
+                      _this2.onSelect(sortField.field);
+                      _this2.toggleSelect();
+                    } },
+                  sortField.label
+                )
+              );
+            }),
+            value ? _react2.default.createElement(
+              "li",
+              null,
+              _react2.default.createElement(
+                "a",
+                { onClick: function onClick() {
+                    _this2.props.onChange(value.field, null);
+                    _this2.toggleSelect();
+                  } },
+                "- clear -"
+              )
+            ) : null
+          )
+        ),
+        value ? _react2.default.createElement(
+          "span",
+          { className: (0, _classnames2.default)({ "btn-group": bootstrapCss }) },
+          _react2.default.createElement(
+            "button",
+            { className: (0, _classnames2.default)({
+                "btn": bootstrapCss,
+                "btn-default": bootstrapCss,
+                "btn-xs": bootstrapCss,
+                active: value.value === "asc"
+              }),
+              onClick: function onClick() {
+                return _this2.props.onChange(value.field, "asc");
+              } },
+            "asc"
+          ),
+          _react2.default.createElement(
+            "button",
+            { className: (0, _classnames2.default)({
+                "btn": bootstrapCss,
+                "btn-default": bootstrapCss,
+                "btn-xs": bootstrapCss,
+                active: value.value === "desc"
+              }),
+              onClick: function onClick() {
+                return _this2.props.onChange(value.field, "desc");
+              } },
+            "desc"
+          )
+        ) : null
+      );
+    }
+  }]);
 
-	return SortMenu;
+  return SortMenu;
 }(_react2.default.Component);
 
 SortMenu.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	onChange: _propTypes2.default.func,
-	sortFields: _propTypes2.default.array
+  bootstrapCss: _propTypes2.default.bool,
+  onChange: _propTypes2.default.func,
+  sortFields: _propTypes2.default.array
 };
 
 exports.default = SortMenu;
@@ -4421,7 +4597,7 @@ exports.default = SortMenu;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -4451,112 +4627,113 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var TextSearch = function (_React$Component) {
-	_inherits(TextSearch, _React$Component);
+  _inherits(TextSearch, _React$Component);
 
-	function TextSearch(props) {
-		_classCallCheck(this, TextSearch);
+  function TextSearch(props) {
+    _classCallCheck(this, TextSearch);
 
-		var _this = _possibleConstructorReturn(this, (TextSearch.__proto__ || Object.getPrototypeOf(TextSearch)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (TextSearch.__proto__ || Object.getPrototypeOf(TextSearch)).call(this, props));
 
-		_this.state = {
-			value: ""
-		};
-		return _this;
-	}
+    _this.state = {
+      value: ""
+    };
+    return _this;
+  }
 
-	_createClass(TextSearch, [{
-		key: "componentWillReceiveProps",
-		value: function componentWillReceiveProps(nextProps) {
-			this.setState({
-				value: nextProps.value
-			});
-		}
-	}, {
-		key: "handleInputChange",
-		value: function handleInputChange(ev) {
-			this.setState({
-				value: ev.target.value
-			});
-		}
-	}, {
-		key: "handleInputKeyDown",
-		value: function handleInputKeyDown(ev) {
-			if (ev.keyCode === 13) {
-				this.handleSubmit();
-			}
-		}
-	}, {
-		key: "handleSubmit",
-		value: function handleSubmit() {
-			this.props.onChange(this.props.field, this.state.value);
-		}
-	}, {
-		key: "toggleExpand",
-		value: function toggleExpand() {
-			this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
-		}
-	}, {
-		key: "render",
-		value: function render() {
-			var _props = this.props,
-			    label = _props.label,
-			    bootstrapCss = _props.bootstrapCss,
-			    collapse = _props.collapse;
+  _createClass(TextSearch, [{
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(nextProps) {
+      this.setState({
+        value: nextProps.value
+      });
+    }
+  }, {
+    key: "handleInputChange",
+    value: function handleInputChange(ev) {
+      this.setState({
+        value: ev.target.value
+      });
+    }
+  }, {
+    key: "handleInputKeyDown",
+    value: function handleInputKeyDown(ev) {
+      if (ev.keyCode === 13) {
+        this.handleSubmit();
+      }
+    }
+  }, {
+    key: "handleSubmit",
+    value: function handleSubmit() {
+      this.props.onChange(this.props.field, this.state.value);
+    }
+  }, {
+    key: "toggleExpand",
+    value: function toggleExpand() {
+      this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _props = this.props,
+          label = _props.label,
+          bootstrapCss = _props.bootstrapCss,
+          collapse = _props.collapse;
 
 
-			return _react2.default.createElement(
-				"li",
-				{ className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }) },
-				_react2.default.createElement(
-					"header",
-					{ onClick: this.toggleExpand.bind(this) },
-					_react2.default.createElement(
-						"h5",
-						null,
-						bootstrapCss ? _react2.default.createElement(
-							"span",
-							null,
-							_react2.default.createElement("span", { className: (0, _classnames2.default)("glyphicon", {
-									"glyphicon-collapse-down": !collapse,
-									"glyphicon-collapse-up": collapse
-								}) }),
-							" "
-						) : null,
-						label
-					)
-				),
-				_react2.default.createElement(
-					"div",
-					{ style: { display: collapse ? "none" : "block" } },
-					_react2.default.createElement("input", {
-						onChange: this.handleInputChange.bind(this),
-						onKeyDown: this.handleInputKeyDown.bind(this),
-						value: this.state.value || "" }),
-					"\xA0",
-					_react2.default.createElement(
-						"button",
-						{ className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-sm": bootstrapCss }), onClick: this.handleSubmit.bind(this) },
-						_react2.default.createElement(_search2.default, null)
-					)
-				)
-			);
-		}
-	}]);
+      return _react2.default.createElement(
+        "li",
+        { className: (0, _classnames2.default)({ "list-group-item": bootstrapCss }) },
+        _react2.default.createElement(
+          "header",
+          { onClick: this.toggleExpand.bind(this) },
+          _react2.default.createElement(
+            "h5",
+            null,
+            bootstrapCss ? _react2.default.createElement(
+              "span",
+              null,
+              _react2.default.createElement("span", { className: (0, _classnames2.default)("glyphicon", {
+                  "glyphicon-collapse-down": !collapse,
+                  "glyphicon-collapse-up": collapse
+                }) }),
+              " "
+            ) : null,
+            label
+          )
+        ),
+        _react2.default.createElement(
+          "div",
+          { style: { display: collapse ? "none" : "block" } },
+          _react2.default.createElement("input", {
+            onChange: this.handleInputChange.bind(this),
+            onKeyDown: this.handleInputKeyDown.bind(this),
+            value: this.state.value || "" }),
+          "\xA0",
+          _react2.default.createElement(
+            "button",
+            { className: (0, _classnames2.default)({ "btn": bootstrapCss, "btn-default": bootstrapCss, "btn-sm": bootstrapCss }),
+              onClick: this.handleSubmit.bind(this) },
+            _react2.default.createElement(_search2.default, null)
+          )
+        )
+      );
+    }
+  }]);
 
-	return TextSearch;
+  return TextSearch;
 }(_react2.default.Component);
 
 TextSearch.defaultProps = {
-	field: null
+  field: null
 };
 
 TextSearch.propTypes = {
-	bootstrapCss: _propTypes2.default.bool,
-	collapse: _propTypes2.default.bool,
-	field: _propTypes2.default.string.isRequired,
-	label: _propTypes2.default.string,
-	onChange: _propTypes2.default.func,
-	onSetCollapse: _propTypes2.default.func
+  bootstrapCss: _propTypes2.default.bool,
+  collapse: _propTypes2.default.bool,
+  field: _propTypes2.default.string.isRequired,
+  label: _propTypes2.default.string,
+  onChange: _propTypes2.default.func,
+  onSetCollapse: _propTypes2.default.func
 };
 
 exports.default = TextSearch;
@@ -4565,7 +4742,7 @@ exports.default = TextSearch;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 exports.SolrClient = exports.defaultComponentPack = exports.SolrFacetedSearch = undefined;
 
@@ -4590,116 +4767,192 @@ exports.SolrClient = _solrClient.SolrClient;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.default = function () {
-	var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
-	var action = arguments[1];
+  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
+  var action = arguments[1];
 
-	switch (action.type) {
-		case "SET_QUERY_FIELDS":
-			return setQueryFields(state, action);
-		case "SET_SEARCH_FIELDS":
-			return _extends({}, state, { searchFields: action.newFields, start: state.pageStrategy === "paginate" ? 0 : null });
-		case "SET_SORT_FIELDS":
-			return _extends({}, state, { sortFields: action.newSortFields, start: state.pageStrategy === "paginate" ? 0 : null });
-		case "SET_FILTERS":
-			return _extends({}, state, { filters: action.newFilters, start: state.pageStrategy === "paginate" ? 0 : null });
-		case "SET_START":
-			return _extends({}, state, { start: action.newStart });
-		case "SET_RESULTS":
-			return action.data.nextCursorMark ? _extends({}, state, { cursorMark: action.data.nextCursorMark }) : state;
-		case "SET_GROUP":
-			return _extends({}, state, { group: action.group });
-	}
+  switch (action.type) {
+    case "SET_QUERY_FIELDS":
+      return setQueryFields(state, action);
+    case "SET_SEARCH_FIELDS":
+      return _extends({}, state, { searchFields: action.newFields, start: state.pageStrategy === "paginate" ? 0 : null });
+    case "SET_SORT_FIELDS":
+      return _extends({}, state, { sortFields: action.newSortFields, start: state.pageStrategy === "paginate" ? 0 : null });
+    case "SET_FILTERS":
+      return _extends({}, state, { filters: action.newFilters, start: state.pageStrategy === "paginate" ? 0 : null });
+    case "SET_START":
+      return _extends({}, state, { start: action.newStart });
+    case "SET_RESULTS":
+      return action.data.nextCursorMark ? _extends({}, state, { cursorMark: action.data.nextCursorMark }) : state;
+    case "SET_GROUP":
+      return _extends({}, state, { group: action.group });
+  }
 
-	return state;
+  return state;
 };
 
 var initialState = {
-	searchFields: [],
-	sortFields: [],
-	rows: 0,
-	url: null,
-	pageStrategy: null,
-	start: null,
-	group: null,
-	hl: null,
-	mainQueryField: null
+  searchFields: [],
+  sortFields: [],
+  rows: 0,
+  url: null,
+  pageStrategy: null,
+  start: null,
+  group: null,
+  hl: null
 };
 
 var setQueryFields = function setQueryFields(state, action) {
-	return _extends({}, state, {
-		searchFields: action.searchFields,
-		sortFields: action.sortFields,
-		url: action.url,
-		rows: action.rows,
-		pageStrategy: action.pageStrategy,
-		start: action.start,
-		group: action.group,
-		hl: action.hl,
-		mainQueryField: action.mainQueryField
-	});
+  return _extends({}, state, {
+    searchFields: action.searchFields,
+    sortFields: action.sortFields,
+    url: action.url,
+    rows: action.rows,
+    pageStrategy: action.pageStrategy,
+    start: action.start,
+    group: action.group,
+    hl: action.hl
+  });
 };
 
 },{}],45:[function(_dereq_,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.default = function () {
-	var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
-	var action = arguments[1];
+  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
+  var action = arguments[1];
 
-	switch (action.type) {
-		case "SET_RESULTS":
-			return _extends({}, state, {
-				docs: action.data.response ? action.data.response.docs : [],
-				grouped: action.data.grouped || {},
-				numFound: action.data.response ? action.data.response.numFound : tryGroupedResultCount(action.data),
-				facets: action.data.facet_counts.facet_fields,
-				highlighting: action.data.highlighting ? action.data.highlighting : [],
-				pending: false
-			});
+  switch (action.type) {
+    case "SET_RESULTS":
+      return _extends({}, state, {
+        docs: action.data.response ? action.data.response.docs : [],
+        grouped: action.data.grouped || {},
+        numFound: action.data.response ? action.data.response.numFound : tryGroupedResultCount(action.data),
+        facets: action.data.facet_counts.facet_fields,
+        highlighting: action.data.highlighting ? action.data.highlighting : [],
+        pending: false
+      });
 
-		case "SET_NEXT_RESULTS":
-			return _extends({}, state, {
-				docs: state.docs.concat(action.data.response.docs),
-				pending: false
-			});
+    case "SET_NEXT_RESULTS":
+      return _extends({}, state, {
+        docs: state.docs.concat(action.data.response.docs),
+        pending: false
+      });
 
-		case "SET_RESULTS_PENDING":
-			return _extends({}, state, { pending: true
-			});
-	}
+    case "SET_RESULTS_PENDING":
+      return _extends({}, state, { pending: true
+      });
+  }
 
-	return state;
+  return state;
 };
 
 var initialState = {
-	facets: {},
-	docs: [],
-	numFound: 0,
-	pending: false,
-	highlighting: []
+  facets: {},
+  docs: [],
+  numFound: 0,
+  pending: false,
+  highlighting: []
 };
 
 var tryGroupedResultCount = function tryGroupedResultCount(data) {
-	if (data.grouped) {
-		for (var key in data.grouped) {
-			if (data.grouped[key].matches) {
-				return data.grouped[key].matches;
-			}
-		}
-	}
-	return 0;
+  if (data.grouped) {
+    for (var key in data.grouped) {
+      if (data.grouped[key].matches) {
+        return data.grouped[key].matches;
+      }
+    }
+  }
+  return 0;
+};
+
+},{}],46:[function(_dereq_,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = function () {
+  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
+  var action = arguments[1];
+
+  switch (action.type) {
+    case "SET_SUGGEST_QUERY":
+      return setSuggestQuery(state, action);
+    case "SET_SEARCH_FIELDS":
+      return setSuggestQueryField(state, action);
+  }
+
+  return state;
+};
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+var initialState = {};
+
+var setSuggestQuery = function setSuggestQuery(state, action) {
+  return _extends({}, action.suggestQuery);
+};
+
+var setSuggestQueryField = function setSuggestQueryField(state, action) {
+  // Clear the suggestQueryField data only if the search field has been cleared.
+  if (action.newFields.filter(function (field) {
+    return field.field === "tm_rendered_item" && field.value === "";
+  }).length) {
+    return _extends.apply(undefined, [{}].concat(_toConsumableArray(state), [{
+      suggestQuery: {
+        value: ""
+      }
+    }]));
+  }
+  return _extends({}, state);
+};
+
+},{}],47:[function(_dereq_,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = function () {
+  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
+  var action = arguments[1];
+
+  switch (action.type) {
+    case "SET_SUGGESTIONS":
+      return _extends({}, state, {
+        docs: action.data.response ? action.data.response.docs : [],
+        suggestionsPending: false
+      });
+
+    case "SET_SUGGESTIONS_PENDING":
+      return _extends({}, state, { suggestionsPending: true
+      });
+  }
+
+  return state;
+};
+
+var initialState = {
+  suggestionsPending: false,
+  docs: []
 };
 
 },{}]},{},[43])(43)

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1,5 +1,5 @@
 import xhr from "xhr";
-import solrQuery from "./solr-query";
+import solrQuery, { solrSuggestQuery } from "./solr-query";
 
 const MAX_INT = 2147483647;
 
@@ -27,6 +27,26 @@ server.submitQuery = (query, callback) => {
   }, (err, resp) => {
     if (resp.statusCode >= 200 && resp.statusCode < 300) {
       callback({type: "SET_RESULTS", data: JSON.parse(resp.body)});
+    } else {
+      console.log("Server error: ", resp.statusCode);
+    }
+  });
+};
+
+server.submitSuggestQuery = (suggestQuery, callback) => {
+  callback({type: "SET_SUGGESTIONS_PENDING"});
+
+  server.performXhr({
+    url: suggestQuery.url,
+    data: solrSuggestQuery(suggestQuery),
+    method: "POST",
+    headers: {
+      "Content-type": "application/x-www-form-urlencoded",
+      ...(suggestQuery.userpass ? {"Authorization": "Basic " + suggestQuery.userpass} : {}),
+    }
+  }, (err, resp) => {
+    if (resp.statusCode >= 200 && resp.statusCode < 300) {
+      callback({type: "SET_SUGGESTIONS", data: JSON.parse(resp.body)});
     } else {
       console.log("Server error: ", resp.statusCode);
     }

--- a/src/api/solr-client.js
+++ b/src/api/solr-client.js
@@ -86,23 +86,30 @@ class SolrClient {
     });
   }
 
-  setSuggestQuery(autocomplete, value) {
+  setSuggestQuery(query, autocomplete, value) {
+    const {searchFields} = query;
+    // Add the current text field value to the searchFields array.
+    const newFields = searchFields
+      .map((searchField) => searchField.field === query.mainQueryField ? {...searchField, value: value} : searchField);
     const payload = {
       type: "SET_SUGGEST_QUERY",
       suggestQuery: {
+        searchFields: newFields,
+        sortFields: query.sortFields,
+        filters: query.filters,
+        userpass: query.userpass,
+        mainQueryField: query.mainQueryField,
+        start: 0,
         mode: autocomplete.mode,
         url: autocomplete.url,
-        suggestQueryField: autocomplete.queryField,
-        searchFields: [{field: autocomplete.queryField, value: value, type: 'text' }],
-        suggestionRows: autocomplete.suggestionRows,
+        rows: autocomplete.suggestionRows,
         value
-      },
+      }
     };
     this.sendSuggestQuery(suggestQueryReducer(this.state.suggestQuery, payload));
   }
 
   sendSuggestQuery(suggestQuery = this.state.suggestQuery) {
-    delete suggestQuery.cursorMark;
     this.state.suggestQuery = suggestQuery;
     server.submitSuggestQuery(suggestQuery, (action) => {
       this.state.suggestions = suggestionReducer(this.state.suggestions, action);

--- a/src/api/solr-client.js
+++ b/src/api/solr-client.js
@@ -199,6 +199,7 @@ class SolrClient {
 
   getHandlers() {
     return {
+      onTextInputChange: this.setSuggestQuery.bind(this),
       onSortFieldChange: this.setSortFieldValue.bind(this),
       onSearchFieldChange: this.setSearchFieldValue.bind(this),
       onFacetSortChange: this.setFacetSort.bind(this),

--- a/src/api/solr-client.js
+++ b/src/api/solr-client.js
@@ -102,7 +102,7 @@ class SolrClient {
         start: 0,
         mode: autocomplete.mode,
         url: autocomplete.url,
-        rows: autocomplete.suggestionRows,
+        rows: autocomplete.suggestionRows || 5,
         value
       }
     };

--- a/src/api/solr-client.js
+++ b/src/api/solr-client.js
@@ -103,6 +103,7 @@ class SolrClient {
         mode: autocomplete.mode,
         url: autocomplete.url,
         rows: autocomplete.suggestionRows || 5,
+        appendWildcard: autocomplete.appendWildcard || false,
         value
       }
     };

--- a/src/api/solr-client.js
+++ b/src/api/solr-client.js
@@ -159,6 +159,11 @@ class SolrClient {
     const payload = {type: "SET_SEARCH_FIELDS", newFields: newFields};
 
     this.sendQuery(queryReducer(this.state.query, payload));
+    // Enable the the autosuggest input to be cleared cleared
+    // but only if autcomplete has been configured.
+    if (Object.hasOwnProperty.call(this.state, "suggestQuery")) {
+      this.state.suggestQuery = suggestQueryReducer(this.state.suggestQuery, payload);
+    }
   }
 
   setFacetSort(field, value) {

--- a/src/api/solr-query.js
+++ b/src/api/solr-query.js
@@ -192,8 +192,9 @@ const buildSuggestQuery = (fields, suggestQueryField) => {
   }).map(function (searchField) {
     // To support search-as-you-type we add a wildcard to match zero or more
     // additional characters at the end of the users search term.
-    // We also set the default field to the mainQueryField.
+    // @see: https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html#TheStandardQueryParser-WildcardSearches
     // @see: https://opensourceconnections.com/blog/2013/06/07/search-as-you-type-with-solr/
+    // We also set the default field to the mainQueryField.
     return `${searchField.value}+${searchField.value}*&df=${searchField.field}`;
   });
   // If there are multiple suggest query fields, join them.

--- a/src/api/solr-query.js
+++ b/src/api/solr-query.js
@@ -194,8 +194,10 @@ const buildSuggestQuery = (fields, suggestQueryField) => {
     // additional characters at the end of the users search term.
     // @see: https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html#TheStandardQueryParser-WildcardSearches
     // @see: https://opensourceconnections.com/blog/2013/06/07/search-as-you-type-with-solr/
-    // We also set the default field to the mainQueryField.
-    return `${searchField.value}+${searchField.value}*&df=${searchField.field}`;
+    // We also set the default field to the suggestQueryField.
+    return searchField.value !== ""
+      ? `${searchField.value}+${searchField.value}*&df=${searchField.field}`
+      : "";
   });
   // If there are multiple suggest query fields, join them.
   if (params.length > 1) {

--- a/src/api/solr-query.js
+++ b/src/api/solr-query.js
@@ -84,30 +84,18 @@ const buildFormat = (format) => Object.keys(format)
   .join("&");
 
 const buildMainQuery = (fields, mainQueryField) => {
-  let qs = "q=";
   let params = fields.filter(function (searchField) {
     return searchField.field === mainQueryField;
   }).map(function (searchField) {
-    return fieldToQueryFilter(searchField);
+    return searchField.value;
   });
-  // If there are multiple main query fields, join them.
-  if (params.length > 1) {
-    qs += params.join("&");
+  // Add value of the mainQueryField to the q param, if there is one.
+  if (params[0]) {
+    return `q=${params[0]}`;
   }
-  // If there is only one main query field, add only it.
-  else if (params.length === 1) {
-    if (params[0] !== null) {
-      qs += params[0];
-    } else {
-      // If query field exists but is null send the wildcard query.
-      qs += "*:*";
-    }
-  }
-  // If there are no main query fields, send the wildcard query.
-  else {
-    qs += "*:*";
-  }
-  return qs;
+
+  // If query field exists but is null/empty/undefined send the wildcard query.
+  return "q=*:*";
 };
 
 const buildHighlight = (highlight) => {

--- a/src/reducers/suggestQuery.js
+++ b/src/reducers/suggestQuery.js
@@ -1,0 +1,17 @@
+const initialState = {};
+
+const setSuggestQuery = (state, action) => {
+  return {
+    ...state,
+    ...action.suggestQuery
+  };
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case "SET_SUGGEST_QUERY":
+      return setSuggestQuery(state, action);
+  }
+
+  return state;
+}

--- a/src/reducers/suggestQuery.js
+++ b/src/reducers/suggestQuery.js
@@ -7,10 +7,29 @@ const setSuggestQuery = (state, action) => {
   };
 };
 
+const setSuggestQueryField = (state, action) => {
+  // Clear the suggestQueryField data only if the search field has been cleared.
+  if (action.newFields.filter(field => field.field === "tm_rendered_item" && field.value ==="").length) {
+    return Object.assign({},
+      ...state,
+      {
+        suggestQuery: {
+          value: ""
+        }
+      },
+    );
+  }
+  return {
+    ...state
+  };
+};
+
 export default function (state = initialState, action) {
   switch (action.type) {
     case "SET_SUGGEST_QUERY":
       return setSuggestQuery(state, action);
+    case "SET_SEARCH_FIELDS":
+      return setSuggestQueryField(state, action);
   }
 
   return state;

--- a/src/reducers/suggestQuery.js
+++ b/src/reducers/suggestQuery.js
@@ -2,7 +2,6 @@ const initialState = {};
 
 const setSuggestQuery = (state, action) => {
   return {
-    ...state,
     ...action.suggestQuery
   };
 };

--- a/src/reducers/suggestions.js
+++ b/src/reducers/suggestions.js
@@ -6,7 +6,6 @@ const initialState = {
 export default function (state = initialState, action) {
   switch (action.type) {
     case "SET_SUGGESTIONS":
-      console.log(action);
       return {
         ...state,
         docs: action.data.response ? action.data.response.docs : [],

--- a/src/reducers/suggestions.js
+++ b/src/reducers/suggestions.js
@@ -1,0 +1,23 @@
+const initialState = {
+  suggestionsPending: false,
+  docs: []
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case "SET_SUGGESTIONS":
+      console.log(action);
+      return {
+        ...state,
+        docs: action.data.response ? action.data.response.docs : [],
+        suggestionsPending: false
+      };
+
+    case "SET_SUGGESTIONS_PENDING":
+      return {
+        ...state, suggestionsPending: true
+      };
+  }
+
+  return state;
+}

--- a/test/api/solr-query.js
+++ b/test/api/solr-query.js
@@ -8,6 +8,7 @@ import {
   fieldToQueryFilter,
   buildQuery,
   buildMainQuery,
+  buildSuggestQuery,
   buildHighlight,
   facetFields,
   facetSorts,
@@ -310,6 +311,40 @@ describe("solr-query", () => { //eslint-disable-line no-undef
     });
   });
 
+  describe("buildSuggestQuery", () => { //eslint-disable-line no-undef
+    it("should create a main query param set to field.value+field.value* and a default field param set to field.field where field.field matches the suggestQueryField value", () => {  //eslint-disable-line no-undef
+      expect(buildSuggestQuery([{
+        type: "text",
+        value: "val",
+        field: "field_name"
+      }], "field_name")).toEqual("q=val+val*&df=field_name");
+    });
+
+    it("should not set a main query when populated search fields do not equal suggestQueryField value", () => {  //eslint-disable-line no-undef
+      expect(buildSuggestQuery([{
+        type: "text",
+        value: "val",
+        field: "field_name"
+      }], "some_other_field_name")).toEqual("q=");
+    });
+
+    it("should not set a main query param when the mainQueryField field value is empty", () => { //eslint-disable-line no-undef
+      expect(buildSuggestQuery([{
+        type: "text",
+        field: "field_name",
+        value: ""
+      }], "field_name")).toEqual("q=");
+    });
+
+    // @todo support query fields / default field being set in config
+    it("should not set a main query when mainQueryField is not set", () => {  //eslint-disable-line no-undef
+      expect(buildSuggestQuery([{
+        type: "text",
+        value: "val",
+        field: "field_name"
+      }], null)).toEqual("q=");
+    });
+  });
 
   describe("buildHighlight", () => { //eslint-disable-line no-undef
     it("should create the hl param even when no further config is added", () => {  //eslint-disable-line no-undef
@@ -462,7 +497,6 @@ describe("solr-query", () => { //eslint-disable-line no-undef
       }])).toEqual("field_name%20asc,other_field_name%20desc");
     });
   });
-
 
   describe("solrQuery", () => {  //eslint-disable-line no-undef
     it("should set the q parameter", () => { //eslint-disable-line no-undef
@@ -631,5 +665,173 @@ describe("solr-query", () => { //eslint-disable-line no-undef
       expect(solrQuery(query).split("&").indexOf("group=on") > -1).toEqual(true);
       expect(solrQuery(query).split("&").indexOf("group.field=grouped_field") > -1).toEqual(true);
     });
+  });
+});
+
+describe("solrSuggestQuery", () => {  //eslint-disable-line no-undef
+  it("should not set the q parameter with no search fields", () => { //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: 0
+    };
+    expect(solrQuery(query).split("&").indexOf("q=")).toEqual(-1);
+  });
+
+  it("should set the fq parameters", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: 0
+    };
+    expect(solrQuery({
+      ...query, searchFields: [
+        {type: "text", field: "field_name", value: "val"}]
+    }).split("&").indexOf("fq=field_name%3Aval") > -1).toEqual(true);
+  });
+
+  it("should set the fq parameters from static filters", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: 0
+    };
+    expect(solrQuery({
+      ...query, filters: [{field: "field_name", value: "val"}]
+    }).split("&").indexOf("fq=field_name%3Aval") > -1).toEqual(true);
+  });
+
+  it("should set the rows parameter", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 5,
+      start: 0
+    };
+    expect(solrQuery(query).split("&").indexOf("rows=5") > -1).toEqual(true);
+  });
+
+  it("should (not) set the sort parameter", () => { //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: 0
+    };
+    expect(solrQuery(query).indexOf("&sort=")).toEqual(-1);
+
+    expect(solrQuery({
+      ...query, sortFields: [{
+        field: "field_name",
+        value: "asc"
+      }]
+    }).split("&").indexOf("sort=field_name%20asc") > -1).toEqual(true);
+  });
+
+  it("should (not) set the facet.field parameters", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: 0
+    };
+    expect(solrQuery(query).indexOf("facet.field")).toEqual(-1);
+
+    expect(solrQuery({
+      ...query, searchFields: [{
+        field: "field_name",
+        type: "list-facet"
+      }]
+    }).split("&").indexOf("facet.field=field_name") > -1).toEqual(true);
+  });
+
+  it("should (not) set the start parameter", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null
+    };
+    expect(solrQuery(query).indexOf("start=")).toEqual(-1);
+    expect(solrQuery({...query, start: 10}).indexOf("start=") > -1).toEqual(true);
+  });
+
+  it("should set the wt parameter to json", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null
+    };
+    expect(solrQuery(query).split("&").indexOf("wt=json") > -1).toEqual(true);
+  });
+
+  it("should set the facet parameter to on", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null
+    };
+    expect(solrQuery(query).split("&").indexOf("facet=on") > -1).toEqual(true);
+  });
+
+  it("should set the facet.limit parameter to -1 by default", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null
+    };
+    expect(solrQuery(query).split("&").indexOf("facet.limit=-1") > -1).toEqual(true);
+  });
+
+  it("should set the facet.limit parameter from the facetLimit prop", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null,
+      facetLimit: 100
+    };
+    expect(solrQuery(query).split("&").indexOf("facet.limit=100") > -1).toEqual(true);
+  });
+
+  it("should set the facet.sort parameter from the facetSort prop", () => {  //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null,
+      facetSort: "index"
+    };
+    expect(solrQuery(query).split("&").indexOf("facet.sort=index") > -1).toEqual(true);
+  });
+
+  it("should set the cursorMark parameter to * when pageStrategy is 'cursor' and cursor is not passed", () => { //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null,
+      facetSort: "index",
+      pageStrategy: "cursor"
+    };
+    expect(solrQuery(query).split("&").indexOf("cursorMark=*") > -1).toEqual(true);
+  });
+
+  it("should set the group param", () => { //eslint-disable-line no-undef
+    const query = {
+      searchFields: [],
+      sortFields: [],
+      rows: 10,
+      start: null,
+      group: {field: "grouped_field"}
+    };
+    expect(solrQuery(query).split("&").indexOf("group=on") > -1).toEqual(true);
+    expect(solrQuery(query).split("&").indexOf("group.field=grouped_field") > -1).toEqual(true);
   });
 });

--- a/test/api/solr-query.js
+++ b/test/api/solr-query.js
@@ -292,12 +292,12 @@ describe("solr-query", () => { //eslint-disable-line no-undef
       }], "some_other_field_name")).toEqual("q=*:*");
     });
 
-    it("should set main query param to null when the mainQueryField field value is empty", () => { //eslint-disable-line no-undef
+    it("should set main query param to wildcards when the mainQueryField field value is empty", () => { //eslint-disable-line no-undef
       expect(buildMainQuery([{
         type: "text",
         field: "field_name",
         value: ""
-      }], "field_name")).toEqual("q=null");
+      }], "field_name")).toEqual("q=*:*");
     });
 
 
@@ -326,7 +326,7 @@ describe("solr-query", () => { //eslint-disable-line no-undef
     it("should join query parts with ampersand", () => {  //eslint-disable-line no-undef
       const query = buildHighlight({
         fl: "field_name",
-        usePhraseHighlighter: true,
+        usePhraseHighlighter: true
       });
 
       const parts = query.split("&");

--- a/test/reducers/suggestQuery.js
+++ b/test/reducers/suggestQuery.js
@@ -1,0 +1,49 @@
+import expect from "expect";
+
+import suggestQueryReducer from "../../src/reducers/suggestQuery";
+
+describe("suggestQueryReducer", () => { //eslint-disable-line no-undef
+
+  it("should SET_SUGGEST_QUERY", () => {  //eslint-disable-line no-undef
+    expect(suggestQueryReducer({
+      init: "bar"
+    }, {
+      type: "SET_SUGGEST_QUERY",
+      suggestQuery: {
+        searchFields: ["x"],
+        sortFields: ["y"],
+        filters: ["z"],
+        userpass: "userpass",
+        mainQueryField: "field",
+        start: 0,
+        mode: "mode",
+        url: "url",
+        rows: 5,
+        value: "value"
+      }
+    })).toEqual({
+      searchFields: ["x"],
+      sortFields: ["y"],
+      filters: ["z"],
+      userpass: "userpass",
+      mainQueryField: "field",
+      start: 0,
+      mode: "mode",
+      url: "url",
+      rows: 5,
+      value: "value"
+    });
+  });
+
+  it("should clear the text search field on SET_SEARCH_FIELDS with mainQueryField empty", () => {  //eslint-disable-line no-undef
+    expect(suggestQueryReducer({},
+      {
+        type: "SET_SEARCH_FIELDS",
+        newFields: [{field: "tm_rendered_item", value: ""}]
+      })).toEqual({
+      suggestQuery: {
+        value: ""
+      }
+    });
+  });
+});

--- a/test/reducers/suggestions.js
+++ b/test/reducers/suggestions.js
@@ -1,0 +1,36 @@
+import expect from "expect";
+
+import suggestionsReducer from "../../src/reducers/suggestions";
+
+describe("suggestionsReducer", () => { //eslint-disable-line no-undef
+
+  it("should SET_SUGGESTIONS", () => { //eslint-disable-line no-undef
+    expect(suggestionsReducer({
+      init: "bar",
+      suggestionsPending: true
+    }, {
+      type: "SET_SUGGESTIONS",
+      data: {
+        response: {
+          docs: ["123"]
+        }
+      }
+    })).toEqual({
+      init: "bar",
+      docs: ["123"],
+      suggestionsPending: false
+    });
+  });
+
+  it("should SET_SUGGESTIONS_PENDING", () => { //eslint-disable-line no-undef
+    expect(suggestionsReducer({
+      init: "bar",
+      suggestionsPending: false
+    }, {
+      type: "SET_SUGGESTIONS_PENDING"
+    })).toEqual({
+      init: "bar",
+      suggestionsPending: true
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the following functionality: 

- the solr client can now handle an event that should trigger a "suggest" query and dispatches an action with the necessary payload, based on autocomplete configuration (which comes from the implementing app)
- two new reducers will handle setting the state of the "suggest" query (which pulls some values from the regular search query for things like credentials, filters, facets) and setting the state of the suggestion results
- two new functions will handle building the "suggest" query
- the "server" will perform a new xhr request for making the "suggest" query and dispatch the appropriate action and payload to on of the new reducers
- this new functionality has added test coverage

This PR also makes the solr client un-opinionated about default / query fields, relying on the implementation's solr config to set these.  This allows flexibility with the default search, autocomplete, and enables field boosting to be set in solr config.

Main and autocomplete queries are now sent with `q=<mainQueryField.value>` as opposed to `q=tm_rendered_item:<mainQueryField.value>` and `q=<mainQueryField.value>+<mainQueryField.value>*&df=mainQueryField.field` respectively.

## To test

1. See corresponding PR in the app repo which has updated its package.json to pull from this branch and follow that PR's test steps for functional test
1. Run tests in this repo by pulling down this branch and running `yarn test`, observe that all tests pass
1. See the test output for `buildSuggestQuery`, `solrSuggestQuery`, `suggestQueryReducer`, `suggestionsReducer` for a high level understanding of what the new code does (as of now, this will likely change a bit this week)

## TODO

1. Alter the suggest query to either a) accept configuration for choosing a query parser + query fields or b) only send the search term and rely on solr config to handle everything else
