### PR TITLE
Platform-1002: Use search as main qs param for D7 proxy implementations

### DIFF
--- a/src/api/solr-client.js
+++ b/src/api/solr-client.js
@@ -94,6 +94,7 @@ class SolrClient {
     const payload = {
       type: "SET_SUGGEST_QUERY",
       suggestQuery: {
+        isD7: query.isD7,
         searchFields: newFields,
         sortFields: query.sortFields,
         filters: query.filters,


### PR DESCRIPTION
Because Drupal 7 does not allow q to be used as a param.  Tested as part of https://github.com/palantirnet/federated-search-react/pull/40